### PR TITLE
Добавил копирайт Dviglo в файлы

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Set CMake minimum version

--- a/Docs/CMakeLists.txt
+++ b/Docs/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Set project name

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Check existence of various header files and their functions required by some of the third-party libraries and Urho3D library

--- a/Source/Clang-Tools/Annotator/Annotator.cpp
+++ b/Source/Clang-Tools/Annotator/Annotator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <clang/ASTMatchers/ASTMatchFinder.h>

--- a/Source/Clang-Tools/Annotator/CMakeLists.txt
+++ b/Source/Clang-Tools/Annotator/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Clang-Tools/AutoBinder/AutoBinder.cpp
+++ b/Source/Clang-Tools/AutoBinder/AutoBinder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <clang/ASTMatchers/ASTMatchFinder.h>

--- a/Source/Clang-Tools/AutoBinder/CMakeLists.txt
+++ b/Source/Clang-Tools/AutoBinder/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Clang-Tools/AutoBinder/Templates/AngelScript/source.mustache
+++ b/Source/Clang-Tools/AutoBinder/Templates/AngelScript/source.mustache
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Clang-Tools/CMakeLists.txt
+++ b/Source/Clang-Tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (CMAKE_PROJECT_NAME STREQUAL Urho3D)

--- a/Source/Extras/CMakeLists.txt
+++ b/Source/Extras/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Set project name

--- a/Source/Extras/CoverityScan/model.cpp
+++ b/Source/Extras/CoverityScan/model.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /* Coverity Scan model

--- a/Source/Extras/OgreBatchConverter/CMakeLists.txt
+++ b/Source/Extras/OgreBatchConverter/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/01_HelloWorld/CMakeLists.txt
+++ b/Source/Samples/01_HelloWorld/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/01_HelloWorld/HelloWorld.cpp
+++ b/Source/Samples/01_HelloWorld/HelloWorld.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/01_HelloWorld/HelloWorld.h
+++ b/Source/Samples/01_HelloWorld/HelloWorld.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/02_HelloGUI/CMakeLists.txt
+++ b/Source/Samples/02_HelloGUI/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/02_HelloGUI/HelloGUI.cpp
+++ b/Source/Samples/02_HelloGUI/HelloGUI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/02_HelloGUI/HelloGUI.h
+++ b/Source/Samples/02_HelloGUI/HelloGUI.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/03_Sprites/CMakeLists.txt
+++ b/Source/Samples/03_Sprites/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/03_Sprites/Sprites.cpp
+++ b/Source/Samples/03_Sprites/Sprites.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/03_Sprites/Sprites.h
+++ b/Source/Samples/03_Sprites/Sprites.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/04_StaticScene/CMakeLists.txt
+++ b/Source/Samples/04_StaticScene/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/04_StaticScene/StaticScene.cpp
+++ b/Source/Samples/04_StaticScene/StaticScene.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/04_StaticScene/StaticScene.h
+++ b/Source/Samples/04_StaticScene/StaticScene.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/05_AnimatingScene/AnimatingScene.cpp
+++ b/Source/Samples/05_AnimatingScene/AnimatingScene.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/05_AnimatingScene/AnimatingScene.h
+++ b/Source/Samples/05_AnimatingScene/AnimatingScene.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/05_AnimatingScene/CMakeLists.txt
+++ b/Source/Samples/05_AnimatingScene/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/05_AnimatingScene/Rotator.cpp
+++ b/Source/Samples/05_AnimatingScene/Rotator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Scene/Scene.h>

--- a/Source/Samples/05_AnimatingScene/Rotator.h
+++ b/Source/Samples/05_AnimatingScene/Rotator.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/06_SkeletalAnimation/CMakeLists.txt
+++ b/Source/Samples/06_SkeletalAnimation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/06_SkeletalAnimation/Mover.cpp
+++ b/Source/Samples/06_SkeletalAnimation/Mover.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Graphics/AnimatedModel.h>

--- a/Source/Samples/06_SkeletalAnimation/Mover.h
+++ b/Source/Samples/06_SkeletalAnimation/Mover.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
+++ b/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.h
+++ b/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/07_Billboards/Billboards.cpp
+++ b/Source/Samples/07_Billboards/Billboards.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/07_Billboards/Billboards.h
+++ b/Source/Samples/07_Billboards/Billboards.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/07_Billboards/CMakeLists.txt
+++ b/Source/Samples/07_Billboards/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/08_Decals/CMakeLists.txt
+++ b/Source/Samples/08_Decals/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/08_Decals/Decals.h
+++ b/Source/Samples/08_Decals/Decals.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/09_MultipleViewports/CMakeLists.txt
+++ b/Source/Samples/09_MultipleViewports/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/09_MultipleViewports/MultipleViewports.cpp
+++ b/Source/Samples/09_MultipleViewports/MultipleViewports.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/09_MultipleViewports/MultipleViewports.h
+++ b/Source/Samples/09_MultipleViewports/MultipleViewports.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/10_RenderToTexture/CMakeLists.txt
+++ b/Source/Samples/10_RenderToTexture/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/10_RenderToTexture/RenderToTexture.cpp
+++ b/Source/Samples/10_RenderToTexture/RenderToTexture.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/10_RenderToTexture/RenderToTexture.h
+++ b/Source/Samples/10_RenderToTexture/RenderToTexture.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/10_RenderToTexture/Rotator.cpp
+++ b/Source/Samples/10_RenderToTexture/Rotator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Scene/Scene.h>

--- a/Source/Samples/10_RenderToTexture/Rotator.h
+++ b/Source/Samples/10_RenderToTexture/Rotator.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/11_Physics/CMakeLists.txt
+++ b/Source/Samples/11_Physics/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/11_Physics/Physics.cpp
+++ b/Source/Samples/11_Physics/Physics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/11_Physics/Physics.h
+++ b/Source/Samples/11_Physics/Physics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/12_PhysicsStressTest/CMakeLists.txt
+++ b/Source/Samples/12_PhysicsStressTest/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
+++ b/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.h
+++ b/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/13_Ragdolls/CMakeLists.txt
+++ b/Source/Samples/13_Ragdolls/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/13_Ragdolls/CreateRagdoll.cpp
+++ b/Source/Samples/13_Ragdolls/CreateRagdoll.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Graphics/AnimatedModel.h>

--- a/Source/Samples/13_Ragdolls/CreateRagdoll.h
+++ b/Source/Samples/13_Ragdolls/CreateRagdoll.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/13_Ragdolls/Ragdolls.cpp
+++ b/Source/Samples/13_Ragdolls/Ragdolls.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/13_Ragdolls/Ragdolls.h
+++ b/Source/Samples/13_Ragdolls/Ragdolls.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/14_SoundEffects/CMakeLists.txt
+++ b/Source/Samples/14_SoundEffects/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/14_SoundEffects/SoundEffects.cpp
+++ b/Source/Samples/14_SoundEffects/SoundEffects.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Audio.h>

--- a/Source/Samples/14_SoundEffects/SoundEffects.h
+++ b/Source/Samples/14_SoundEffects/SoundEffects.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/15_Navigation/CMakeLists.txt
+++ b/Source/Samples/15_Navigation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NAVIGATION)

--- a/Source/Samples/15_Navigation/Navigation.cpp
+++ b/Source/Samples/15_Navigation/Navigation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/15_Navigation/Navigation.h
+++ b/Source/Samples/15_Navigation/Navigation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/16_Chat/CMakeLists.txt
+++ b/Source/Samples/16_Chat/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NETWORK)

--- a/Source/Samples/16_Chat/Chat.cpp
+++ b/Source/Samples/16_Chat/Chat.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Audio.h>

--- a/Source/Samples/16_Chat/Chat.h
+++ b/Source/Samples/16_Chat/Chat.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/17_SceneReplication/CMakeLists.txt
+++ b/Source/Samples/17_SceneReplication/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NETWORK OR NOT URHO3D_PHYSICS)

--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/17_SceneReplication/SceneReplication.h
+++ b/Source/Samples/17_SceneReplication/SceneReplication.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/18_CharacterDemo/CMakeLists.txt
+++ b/Source/Samples/18_CharacterDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/18_CharacterDemo/Character.cpp
+++ b/Source/Samples/18_CharacterDemo/Character.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Samples/18_CharacterDemo/Character.h
+++ b/Source/Samples/18_CharacterDemo/Character.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
+++ b/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/18_CharacterDemo/CharacterDemo.h
+++ b/Source/Samples/18_CharacterDemo/CharacterDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/18_CharacterDemo/Touch.cpp
+++ b/Source/Samples/18_CharacterDemo/Touch.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Graphics/Graphics.h>

--- a/Source/Samples/18_CharacterDemo/Touch.h
+++ b/Source/Samples/18_CharacterDemo/Touch.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/19_VehicleDemo/CMakeLists.txt
+++ b/Source/Samples/19_VehicleDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/19_VehicleDemo/Vehicle.cpp
+++ b/Source/Samples/19_VehicleDemo/Vehicle.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Samples/19_VehicleDemo/Vehicle.h
+++ b/Source/Samples/19_VehicleDemo/Vehicle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
+++ b/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/19_VehicleDemo/VehicleDemo.h
+++ b/Source/Samples/19_VehicleDemo/VehicleDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/20_HugeObjectCount/CMakeLists.txt
+++ b/Source/Samples/20_HugeObjectCount/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/20_HugeObjectCount/HugeObjectCount.cpp
+++ b/Source/Samples/20_HugeObjectCount/HugeObjectCount.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/20_HugeObjectCount/HugeObjectCount.h
+++ b/Source/Samples/20_HugeObjectCount/HugeObjectCount.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
+++ b/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/AngelScript/Script.h>

--- a/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.h
+++ b/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/21_AngelScriptIntegration/CMakeLists.txt
+++ b/Source/Samples/21_AngelScriptIntegration/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_ANGELSCRIPT)

--- a/Source/Samples/23_Water/CMakeLists.txt
+++ b/Source/Samples/23_Water/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/23_Water/Water.cpp
+++ b/Source/Samples/23_Water/Water.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/23_Water/Water.h
+++ b/Source/Samples/23_Water/Water.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/24_Urho2DSprite/CMakeLists.txt
+++ b/Source/Samples/24_Urho2DSprite/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D)

--- a/Source/Samples/24_Urho2DSprite/Urho2DSprite.cpp
+++ b/Source/Samples/24_Urho2DSprite/Urho2DSprite.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/24_Urho2DSprite/Urho2DSprite.h
+++ b/Source/Samples/24_Urho2DSprite/Urho2DSprite.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/25_Urho2DParticle/CMakeLists.txt
+++ b/Source/Samples/25_Urho2DParticle/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D)

--- a/Source/Samples/25_Urho2DParticle/Urho2DParticle.cpp
+++ b/Source/Samples/25_Urho2DParticle/Urho2DParticle.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/25_Urho2DParticle/Urho2DParticle.h
+++ b/Source/Samples/25_Urho2DParticle/Urho2DParticle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/26_ConsoleInput/CMakeLists.txt
+++ b/Source/Samples/26_ConsoleInput/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/26_ConsoleInput/ConsoleInput.cpp
+++ b/Source/Samples/26_ConsoleInput/ConsoleInput.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/26_ConsoleInput/ConsoleInput.h
+++ b/Source/Samples/26_ConsoleInput/ConsoleInput.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/27_Physics2D/CMakeLists.txt
+++ b/Source/Samples/27_Physics2D/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D OR NOT URHO3D_PHYSICS2D)

--- a/Source/Samples/27_Physics2D/Urho2DPhysics.cpp
+++ b/Source/Samples/27_Physics2D/Urho2DPhysics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/27_Physics2D/Urho2DPhysics.h
+++ b/Source/Samples/27_Physics2D/Urho2DPhysics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/28_Physics2DRope/CMakeLists.txt
+++ b/Source/Samples/28_Physics2DRope/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D OR NOT URHO3D_PHYSICS2D)

--- a/Source/Samples/28_Physics2DRope/Urho2DPhysicsRope.cpp
+++ b/Source/Samples/28_Physics2DRope/Urho2DPhysicsRope.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/28_Physics2DRope/Urho2DPhysicsRope.h
+++ b/Source/Samples/28_Physics2DRope/Urho2DPhysicsRope.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/29_SoundSynthesis/CMakeLists.txt
+++ b/Source/Samples/29_SoundSynthesis/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/29_SoundSynthesis/SoundSynthesis.cpp
+++ b/Source/Samples/29_SoundSynthesis/SoundSynthesis.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/BufferedSoundStream.h>

--- a/Source/Samples/29_SoundSynthesis/SoundSynthesis.h
+++ b/Source/Samples/29_SoundSynthesis/SoundSynthesis.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/30_LightAnimation/CMakeLists.txt
+++ b/Source/Samples/30_LightAnimation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/30_LightAnimation/LightAnimation.cpp
+++ b/Source/Samples/30_LightAnimation/LightAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/30_LightAnimation/LightAnimation.h
+++ b/Source/Samples/30_LightAnimation/LightAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/31_MaterialAnimation/CMakeLists.txt
+++ b/Source/Samples/31_MaterialAnimation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/31_MaterialAnimation/MaterialAnimation.cpp
+++ b/Source/Samples/31_MaterialAnimation/MaterialAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/31_MaterialAnimation/MaterialAnimation.h
+++ b/Source/Samples/31_MaterialAnimation/MaterialAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/32_Physics2DConstraints/CMakeLists.txt
+++ b/Source/Samples/32_Physics2DConstraints/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D OR NOT URHO3D_PHYSICS2D)

--- a/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.cpp
+++ b/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Container/Vector.h>

--- a/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.h
+++ b/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/33_Urho2DSpriterAnimation/CMakeLists.txt
+++ b/Source/Samples/33_Urho2DSpriterAnimation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D)

--- a/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.cpp
+++ b/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.h
+++ b/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/34_DynamicGeometry/CMakeLists.txt
+++ b/Source/Samples/34_DynamicGeometry/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
+++ b/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/34_DynamicGeometry/DynamicGeometry.h
+++ b/Source/Samples/34_DynamicGeometry/DynamicGeometry.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/35_SignedDistanceFieldText/CMakeLists.txt
+++ b/Source/Samples/35_SignedDistanceFieldText/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.cpp
+++ b/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.h
+++ b/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/36_Urho2DTileMap/CMakeLists.txt
+++ b/Source/Samples/36_Urho2DTileMap/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D)

--- a/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.cpp
+++ b/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.h
+++ b/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/37_UIDrag/CMakeLists.txt
+++ b/Source/Samples/37_UIDrag/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/37_UIDrag/UIDrag.cpp
+++ b/Source/Samples/37_UIDrag/UIDrag.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/37_UIDrag/UIDrag.h
+++ b/Source/Samples/37_UIDrag/UIDrag.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/38_SceneAndUILoad/CMakeLists.txt
+++ b/Source/Samples/38_SceneAndUILoad/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
+++ b/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.h
+++ b/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/39_CrowdNavigation/CMakeLists.txt
+++ b/Source/Samples/39_CrowdNavigation/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NAVIGATION)

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.h
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/40_Localization/CMakeLists.txt
+++ b/Source/Samples/40_Localization/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/40_Localization/L10n.cpp
+++ b/Source/Samples/40_Localization/L10n.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/40_Localization/L10n.h
+++ b/Source/Samples/40_Localization/L10n.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/41_DatabaseDemo/CMakeLists.txt
+++ b/Source/Samples/41_DatabaseDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_DATABASE_ODBC AND NOT URHO3D_DATABASE_SQLITE)

--- a/Source/Samples/41_DatabaseDemo/DatabaseDemo.cpp
+++ b/Source/Samples/41_DatabaseDemo/DatabaseDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/41_DatabaseDemo/DatabaseDemo.h
+++ b/Source/Samples/41_DatabaseDemo/DatabaseDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/42_PBRMaterials/CMakeLists.txt
+++ b/Source/Samples/42_PBRMaterials/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Emscripten build does not copy the PBR resources, and would not support the shaders

--- a/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
+++ b/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/42_PBRMaterials/PBRMaterials.h
+++ b/Source/Samples/42_PBRMaterials/PBRMaterials.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/43_HttpRequestDemo/CMakeLists.txt
+++ b/Source/Samples/43_HttpRequestDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NETWORK)

--- a/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
+++ b/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.h
+++ b/Source/Samples/43_HttpRequestDemo/HttpRequestDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/44_RibbonTrailDemo/CMakeLists.txt
+++ b/Source/Samples/44_RibbonTrailDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.cpp
+++ b/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.h
+++ b/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/45_InverseKinematics/CMakeLists.txt
+++ b/Source/Samples/45_InverseKinematics/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_IK OR NOT URHO3D_PHYSICS)

--- a/Source/Samples/45_InverseKinematics/InverseKinematics.cpp
+++ b/Source/Samples/45_InverseKinematics/InverseKinematics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/45_InverseKinematics/InverseKinematics.h
+++ b/Source/Samples/45_InverseKinematics/InverseKinematics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/46_RaycastVehicle/CMakeLists.txt
+++ b/Source/Samples/46_RaycastVehicle/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PHYSICS)

--- a/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.cpp
+++ b/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.h
+++ b/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/46_RaycastVehicle/Vehicle.cpp
+++ b/Source/Samples/46_RaycastVehicle/Vehicle.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Vehicle.h"

--- a/Source/Samples/46_RaycastVehicle/Vehicle.h
+++ b/Source/Samples/46_RaycastVehicle/Vehicle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/47_Typography/CMakeLists.txt
+++ b/Source/Samples/47_Typography/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/47_Typography/Typography.cpp
+++ b/Source/Samples/47_Typography/Typography.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/47_Typography/Typography.h
+++ b/Source/Samples/47_Typography/Typography.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/48_Hello3DUI/CMakeLists.txt
+++ b/Source/Samples/48_Hello3DUI/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/48_Hello3DUI/Hello3DUI.cpp
+++ b/Source/Samples/48_Hello3DUI/Hello3DUI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/48_Hello3DUI/Hello3DUI.h
+++ b/Source/Samples/48_Hello3DUI/Hello3DUI.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/49_Urho2DIsometricDemo/CMakeLists.txt
+++ b/Source/Samples/49_Urho2DIsometricDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D OR NOT URHO3D_PHYSICS2D)

--- a/Source/Samples/49_Urho2DIsometricDemo/Character2D.cpp
+++ b/Source/Samples/49_Urho2DIsometricDemo/Character2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Samples/49_Urho2DIsometricDemo/Character2D.h
+++ b/Source/Samples/49_Urho2DIsometricDemo/Character2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.cpp
+++ b/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.h
+++ b/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/50_Urho2DPlatformer/CMakeLists.txt
+++ b/Source/Samples/50_Urho2DPlatformer/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D OR NOT URHO3D_PHYSICS2D)

--- a/Source/Samples/50_Urho2DPlatformer/Character2D.cpp
+++ b/Source/Samples/50_Urho2DPlatformer/Character2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Samples/50_Urho2DPlatformer/Character2D.h
+++ b/Source/Samples/50_Urho2DPlatformer/Character2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.cpp
+++ b/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Audio.h>

--- a/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.h
+++ b/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/51_Urho2DStretchableSprite/CMakeLists.txt
+++ b/Source/Samples/51_Urho2DStretchableSprite/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_URHO2D)

--- a/Source/Samples/51_Urho2DStretchableSprite/Urho2DStretchableSprite.cpp
+++ b/Source/Samples/51_Urho2DStretchableSprite/Urho2DStretchableSprite.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/51_Urho2DStretchableSprite/Urho2DStretchableSprite.h
+++ b/Source/Samples/51_Urho2DStretchableSprite/Urho2DStretchableSprite.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/52_NATPunchtrough/CMakeLists.txt
+++ b/Source/Samples/52_NATPunchtrough/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NETWORK)

--- a/Source/Samples/52_NATPunchtrough/NATPunchtrough.cpp
+++ b/Source/Samples/52_NATPunchtrough/NATPunchtrough.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Audio.h>

--- a/Source/Samples/52_NATPunchtrough/NATPunchtrough.h
+++ b/Source/Samples/52_NATPunchtrough/NATPunchtrough.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/53_LANDiscovery/CMakeLists.txt
+++ b/Source/Samples/53_LANDiscovery/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_NETWORK)

--- a/Source/Samples/53_LANDiscovery/LANDiscovery.cpp
+++ b/Source/Samples/53_LANDiscovery/LANDiscovery.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Audio.h>

--- a/Source/Samples/53_LANDiscovery/LANDiscovery.h
+++ b/Source/Samples/53_LANDiscovery/LANDiscovery.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/54_WindowSettingsDemo/CMakeLists.txt
+++ b/Source/Samples/54_WindowSettingsDemo/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/54_WindowSettingsDemo/WindowSettingsDemo.cpp
+++ b/Source/Samples/54_WindowSettingsDemo/WindowSettingsDemo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/54_WindowSettingsDemo/WindowSettingsDemo.h
+++ b/Source/Samples/54_WindowSettingsDemo/WindowSettingsDemo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/55_Clicker/CMakeLists.txt
+++ b/Source/Samples/55_Clicker/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/55_Clicker/Clicker.cpp
+++ b/Source/Samples/55_Clicker/Clicker.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/CoreEvents.h>

--- a/Source/Samples/55_Clicker/Clicker.h
+++ b/Source/Samples/55_Clicker/Clicker.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/56_SpriteBatch/CMakeLists.txt
+++ b/Source/Samples/56_SpriteBatch/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/99_Benchmark/AppStateManager.cpp
+++ b/Source/Samples/99_Benchmark/AppStateManager.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppStateManager.h"

--- a/Source/Samples/99_Benchmark/AppStateManager.h
+++ b/Source/Samples/99_Benchmark/AppStateManager.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_Base.cpp
+++ b/Source/Samples/99_Benchmark/AppState_Base.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_Base.h"

--- a/Source/Samples/99_Benchmark/AppState_Base.h
+++ b/Source/Samples/99_Benchmark/AppState_Base.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_Benchmark01.cpp
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark01.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_Benchmark01.h"

--- a/Source/Samples/99_Benchmark/AppState_Benchmark01.h
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark01.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_Benchmark02.cpp
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark02.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_Benchmark02.h"

--- a/Source/Samples/99_Benchmark/AppState_Benchmark02.h
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark02.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_Benchmark03.cpp
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark03.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_Benchmark03.h"

--- a/Source/Samples/99_Benchmark/AppState_Benchmark03.h
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark03.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_Benchmark04.cpp
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark04.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_Benchmark04.h"

--- a/Source/Samples/99_Benchmark/AppState_Benchmark04.h
+++ b/Source/Samples/99_Benchmark/AppState_Benchmark04.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_MainScreen.cpp
+++ b/Source/Samples/99_Benchmark/AppState_MainScreen.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_MainScreen.h"

--- a/Source/Samples/99_Benchmark/AppState_MainScreen.h
+++ b/Source/Samples/99_Benchmark/AppState_MainScreen.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/AppState_ResultScreen.cpp
+++ b/Source/Samples/99_Benchmark/AppState_ResultScreen.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppState_ResultScreen.h"

--- a/Source/Samples/99_Benchmark/AppState_ResultScreen.h
+++ b/Source/Samples/99_Benchmark/AppState_ResultScreen.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/Benchmark02_WomanMover.cpp
+++ b/Source/Samples/99_Benchmark/Benchmark02_WomanMover.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Benchmark02_WomanMover.h"

--- a/Source/Samples/99_Benchmark/Benchmark02_WomanMover.h
+++ b/Source/Samples/99_Benchmark/Benchmark02_WomanMover.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.cpp
+++ b/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Benchmark03_MoleculeLogic.h"

--- a/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.h
+++ b/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/CMakeLists.txt
+++ b/Source/Samples/99_Benchmark/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Samples/99_Benchmark/FpsCounter.cpp
+++ b/Source/Samples/99_Benchmark/FpsCounter.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "FpsCounter.h"

--- a/Source/Samples/99_Benchmark/FpsCounter.h
+++ b/Source/Samples/99_Benchmark/FpsCounter.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/99_Benchmark/Main.cpp
+++ b/Source/Samples/99_Benchmark/Main.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "AppStateManager.h"

--- a/Source/Samples/CMakeLists.txt
+++ b/Source/Samples/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_SAMPLES)

--- a/Source/Samples/Sample.h
+++ b/Source/Samples/Sample.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/Sample.inl
+++ b/Source/Samples/Sample.inl
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Timer.h>

--- a/Source/Samples/Utilities2D/Mover.cpp
+++ b/Source/Samples/Utilities2D/Mover.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Urho2D/AnimatedSprite2D.h>

--- a/Source/Samples/Utilities2D/Mover.h
+++ b/Source/Samples/Utilities2D/Mover.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Samples/Utilities2D/Sample2D.cpp
+++ b/Source/Samples/Utilities2D/Sample2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Audio/Sound.h>

--- a/Source/Samples/Utilities2D/Sample2D.h
+++ b/Source/Samples/Utilities2D/Sample2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/ThirdParty/.clang-tidy
+++ b/Source/ThirdParty/.clang-tidy
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 ---

--- a/Source/ThirdParty/AngelScript/CMakeLists.txt
+++ b/Source/ThirdParty/AngelScript/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Box2D/CMakeLists.txt
+++ b/Source/ThirdParty/Box2D/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Bullet/CMakeLists.txt
+++ b/Source/ThirdParty/Bullet/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Civetweb/CMakeLists.txt
+++ b/Source/ThirdParty/Civetweb/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Detour/CMakeLists.txt
+++ b/Source/ThirdParty/Detour/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/DetourCrowd/CMakeLists.txt
+++ b/Source/ThirdParty/DetourCrowd/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/DetourTileCache/CMakeLists.txt
+++ b/Source/ThirdParty/DetourTileCache/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/ETCPACK/CMakeLists.txt
+++ b/Source/ThirdParty/ETCPACK/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/FreeType/CMakeLists.txt
+++ b/Source/ThirdParty/FreeType/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/GLEW/CMakeLists.txt
+++ b/Source/ThirdParty/GLEW/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/LZ4/CMakeLists.txt
+++ b/Source/ThirdParty/LZ4/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/LibCpuId/CMakeLists.txt
+++ b/Source/ThirdParty/LibCpuId/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Mustache/CMakeLists.txt
+++ b/Source/ThirdParty/Mustache/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/PugiXml/CMakeLists.txt
+++ b/Source/ThirdParty/PugiXml/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Recast/CMakeLists.txt
+++ b/Source/ThirdParty/Recast/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/SDL/CMakeLists.txt
+++ b/Source/ThirdParty/SDL/CMakeLists.txt
@@ -22,6 +22,7 @@
 # Modified for Urho3D, the modified portion is licensed under below license
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Urho3D: This hack allows build 32-bit version on Linux Mint x64

--- a/Source/ThirdParty/SDL/cmake/macros.cmake
+++ b/Source/ThirdParty/SDL/cmake/macros.cmake
@@ -22,6 +22,7 @@
 # Modified by Yao Wei Tjong for Urho3D, the modified portion is licensed under below license
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 macro(SET_OPTION _NAME _DESC)

--- a/Source/ThirdParty/SDL/cmake/sdlchecks.cmake
+++ b/Source/ThirdParty/SDL/cmake/sdlchecks.cmake
@@ -22,6 +22,7 @@
 # Modified by Yao Wei Tjong for Urho3D, the modified portion is licensed under below license
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Urho3D - replaced FindLibraryAndSONAME macro with get_soname macro

--- a/Source/ThirdParty/SQLite/CMakeLists.txt
+++ b/Source/ThirdParty/SQLite/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/STB/CMakeLists.txt
+++ b/Source/ThirdParty/STB/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/StanHull/CMakeLists.txt
+++ b/Source/ThirdParty/StanHull/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/Tracy/CMakeLists.txt
+++ b/Source/ThirdParty/Tracy/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/WebP/CMakeLists.txt
+++ b/Source/ThirdParty/WebP/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/boost/CMakeLists.txt
+++ b/Source/ThirdParty/boost/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/ik/CMakeLists.txt
+++ b/Source/ThirdParty/ik/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 include (CheckIncludeFiles)

--- a/Source/ThirdParty/nanodbc/CMakeLists.txt
+++ b/Source/ThirdParty/nanodbc/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/ThirdParty/rapidjson/CMakeLists.txt
+++ b/Source/ThirdParty/rapidjson/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/AssetImporter/AssetImporter.cpp
+++ b/Source/Tools/AssetImporter/AssetImporter.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Tools/AssetImporter/CMakeLists.txt
+++ b/Source/Tools/AssetImporter/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/BindingGenerator/ASClassBinder.cpp
+++ b/Source/Tools/BindingGenerator/ASClassBinder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASResult.h"

--- a/Source/Tools/BindingGenerator/ASEnumBinder.cpp
+++ b/Source/Tools/BindingGenerator/ASEnumBinder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASResult.h"

--- a/Source/Tools/BindingGenerator/ASGlobalFunctionBinder.cpp
+++ b/Source/Tools/BindingGenerator/ASGlobalFunctionBinder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASResult.h"

--- a/Source/Tools/BindingGenerator/ASGlobalVariableBinder.cpp
+++ b/Source/Tools/BindingGenerator/ASGlobalVariableBinder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASResult.h"

--- a/Source/Tools/BindingGenerator/ASResult.cpp
+++ b/Source/Tools/BindingGenerator/ASResult.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASResult.h"

--- a/Source/Tools/BindingGenerator/ASResult.h
+++ b/Source/Tools/BindingGenerator/ASResult.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/BindingGenerator/ASTemplateGenerator.cpp
+++ b/Source/Tools/BindingGenerator/ASTemplateGenerator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <fstream>

--- a/Source/Tools/BindingGenerator/ASUtils.cpp
+++ b/Source/Tools/BindingGenerator/ASUtils.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "ASUtils.h"

--- a/Source/Tools/BindingGenerator/ASUtils.h
+++ b/Source/Tools/BindingGenerator/ASUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/BindingGenerator/CMakeLists.txt
+++ b/Source/Tools/BindingGenerator/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT CMAKE_PROJECT_NAME STREQUAL Urho3D)

--- a/Source/Tools/BindingGenerator/Main.cpp
+++ b/Source/Tools/BindingGenerator/Main.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <chrono>

--- a/Source/Tools/BindingGenerator/Tuning.cpp
+++ b/Source/Tools/BindingGenerator/Tuning.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // Functions that users can change to affect the work BindingGenerator

--- a/Source/Tools/BindingGenerator/Tuning.h
+++ b/Source/Tools/BindingGenerator/Tuning.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/BindingGenerator/Utils.cpp
+++ b/Source/Tools/BindingGenerator/Utils.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Utils.h"

--- a/Source/Tools/BindingGenerator/Utils.h
+++ b/Source/Tools/BindingGenerator/Utils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/BindingGenerator/XmlAnalyzer.cpp
+++ b/Source/Tools/BindingGenerator/XmlAnalyzer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Utils.h"

--- a/Source/Tools/BindingGenerator/XmlAnalyzer.h
+++ b/Source/Tools/BindingGenerator/XmlAnalyzer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/BindingGenerator/XmlSourceData.cpp
+++ b/Source/Tools/BindingGenerator/XmlSourceData.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Utils.h"

--- a/Source/Tools/BindingGenerator/XmlSourceData.h
+++ b/Source/Tools/BindingGenerator/XmlSourceData.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Set project name

--- a/Source/Tools/OgreImporter/CMakeLists.txt
+++ b/Source/Tools/OgreImporter/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/OgreImporter/OgreImporter.cpp
+++ b/Source/Tools/OgreImporter/OgreImporter.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Tools/OgreImporter/OgreImporterUtils.h
+++ b/Source/Tools/OgreImporter/OgreImporterUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/PackageTool/CMakeLists.txt
+++ b/Source/Tools/PackageTool/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT CMAKE_PROJECT_NAME STREQUAL Urho3D)

--- a/Source/Tools/PackageTool/PackageTool.cpp
+++ b/Source/Tools/PackageTool/PackageTool.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Tools/RampGenerator/CMakeLists.txt
+++ b/Source/Tools/RampGenerator/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/RampGenerator/RampGenerator.cpp
+++ b/Source/Tools/RampGenerator/RampGenerator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Container/ArrayPtr.h>

--- a/Source/Tools/ScriptCompiler/CMakeLists.txt
+++ b/Source/Tools/ScriptCompiler/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/ScriptCompiler/ScriptCompiler.cpp
+++ b/Source/Tools/ScriptCompiler/ScriptCompiler.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/AngelScript/Script.h>

--- a/Source/Tools/SpritePacker/CMakeLists.txt
+++ b/Source/Tools/SpritePacker/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/Core/Context.h>

--- a/Source/Tools/Tests/CMakeLists.txt
+++ b/Source/Tools/Tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Tools/Tests/Container/Str.cpp
+++ b/Source/Tools/Tests/Container/Str.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../ForceAssert.h"

--- a/Source/Tools/Tests/ForceAssert.h
+++ b/Source/Tools/Tests/ForceAssert.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Tools/Tests/Main.cpp
+++ b/Source/Tools/Tests/Main.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <iostream>

--- a/Source/Tools/Tests/Math/BigInt.cpp
+++ b/Source/Tools/Tests/Math/BigInt.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../ForceAssert.h"

--- a/Source/Tools/Urho3DPlayer/CMakeLists.txt
+++ b/Source/Tools/Urho3DPlayer/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if (NOT URHO3D_PLAYER)

--- a/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
+++ b/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_ANGELSCRIPT

--- a/Source/Tools/Urho3DPlayer/Urho3DPlayer.h
+++ b/Source/Tools/Urho3DPlayer/Urho3DPlayer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Addons.cpp
+++ b/Source/Urho3D/AngelScript/Addons.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Addons.h
+++ b/Source/Urho3D/AngelScript/Addons.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/CoreAPI.cpp
+++ b/Source/Urho3D/AngelScript/CoreAPI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual.cpp
+++ b/Source/Urho3D/AngelScript/Manual.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual.h
+++ b/Source/Urho3D/AngelScript/Manual.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Audio.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Audio.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Container.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Container.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Container.h
+++ b/Source/Urho3D/AngelScript/Manual_Container.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Core.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Core.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Core.h
+++ b/Source/Urho3D/AngelScript/Manual_Core.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Database.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Database.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_DATABASE

--- a/Source/Urho3D/AngelScript/Manual_Engine.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Engine.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Graphics.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Graphics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Graphics.h
+++ b/Source/Urho3D/AngelScript/Manual_Graphics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_IK.cpp
+++ b/Source/Urho3D/AngelScript/Manual_IK.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_IK

--- a/Source/Urho3D/AngelScript/Manual_IO.cpp
+++ b/Source/Urho3D/AngelScript/Manual_IO.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_IO.h
+++ b/Source/Urho3D/AngelScript/Manual_IO.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Input.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Input.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Input.h
+++ b/Source/Urho3D/AngelScript/Manual_Input.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Math.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Math.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Math.h
+++ b/Source/Urho3D/AngelScript/Manual_Math.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Navigation.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Navigation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_NAVIGATION

--- a/Source/Urho3D/AngelScript/Manual_Navigation.h
+++ b/Source/Urho3D/AngelScript/Manual_Navigation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Network.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Network.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_NETWORK

--- a/Source/Urho3D/AngelScript/Manual_Network.h
+++ b/Source/Urho3D/AngelScript/Manual_Network.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Physics.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Physics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_PHYSICS

--- a/Source/Urho3D/AngelScript/Manual_Physics.h
+++ b/Source/Urho3D/AngelScript/Manual_Physics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Physics2D.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Physics2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_PHYSICS2D

--- a/Source/Urho3D/AngelScript/Manual_Physics2D.h
+++ b/Source/Urho3D/AngelScript/Manual_Physics2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Resource.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Resource.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Resource.h
+++ b/Source/Urho3D/AngelScript/Manual_Resource.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_Scene.cpp
+++ b/Source/Urho3D/AngelScript/Manual_Scene.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_Scene.h
+++ b/Source/Urho3D/AngelScript/Manual_Scene.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/Manual_UI.cpp
+++ b/Source/Urho3D/AngelScript/Manual_UI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Manual_UI.h
+++ b/Source/Urho3D/AngelScript/Manual_UI.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/RegistrationMacros.h
+++ b/Source/Urho3D/AngelScript/RegistrationMacros.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Script.cpp
+++ b/Source/Urho3D/AngelScript/Script.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/Script.h
+++ b/Source/Urho3D/AngelScript/Script.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/AngelScript/ScriptAPI.cpp
+++ b/Source/Urho3D/AngelScript/ScriptAPI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/ScriptAPI.h
+++ b/Source/Urho3D/AngelScript/ScriptAPI.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
+++ b/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/ScriptEventListener.h
+++ b/Source/Urho3D/AngelScript/ScriptEventListener.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/ScriptFile.h
+++ b/Source/Urho3D/AngelScript/ScriptFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/AngelScript/ScriptInstance.cpp
+++ b/Source/Urho3D/AngelScript/ScriptInstance.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/AngelScript/ScriptInstance.h
+++ b/Source/Urho3D/AngelScript/ScriptInstance.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/AngelScript/wrap.h
+++ b/Source/Urho3D/AngelScript/wrap.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/Audio.cpp
+++ b/Source/Urho3D/Audio/Audio.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/Audio.h
+++ b/Source/Urho3D/Audio/Audio.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/AudioDefs.h
+++ b/Source/Urho3D/Audio/AudioDefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/AudioEvents.h
+++ b/Source/Urho3D/Audio/AudioEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/BufferedSoundStream.cpp
+++ b/Source/Urho3D/Audio/BufferedSoundStream.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/BufferedSoundStream.h
+++ b/Source/Urho3D/Audio/BufferedSoundStream.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/OggVorbisSoundStream.cpp
+++ b/Source/Urho3D/Audio/OggVorbisSoundStream.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/OggVorbisSoundStream.h
+++ b/Source/Urho3D/Audio/OggVorbisSoundStream.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/Sound.cpp
+++ b/Source/Urho3D/Audio/Sound.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/Sound.h
+++ b/Source/Urho3D/Audio/Sound.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/SoundListener.cpp
+++ b/Source/Urho3D/Audio/SoundListener.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/SoundListener.h
+++ b/Source/Urho3D/Audio/SoundListener.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/SoundSource.cpp
+++ b/Source/Urho3D/Audio/SoundSource.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/SoundSource.h
+++ b/Source/Urho3D/Audio/SoundSource.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/SoundSource3D.cpp
+++ b/Source/Urho3D/Audio/SoundSource3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/SoundSource3D.h
+++ b/Source/Urho3D/Audio/SoundSource3D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Audio/SoundStream.cpp
+++ b/Source/Urho3D/Audio/SoundStream.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Audio/SoundStream.h
+++ b/Source/Urho3D/Audio/SoundStream.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Base/PrimitiveTypes.cpp
+++ b/Source/Urho3D/Base/PrimitiveTypes.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <cstddef> // std::ptrdiff_t

--- a/Source/Urho3D/Base/PrimitiveTypes.h
+++ b/Source/Urho3D/Base/PrimitiveTypes.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Base/Utils.h
+++ b/Source/Urho3D/Base/Utils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define target name

--- a/Source/Urho3D/Container/Allocator.cpp
+++ b/Source/Urho3D/Container/Allocator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/Allocator.h
+++ b/Source/Urho3D/Container/Allocator.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Container/ArrayPtr.h
+++ b/Source/Urho3D/Container/ArrayPtr.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/FlagSet.h
+++ b/Source/Urho3D/Container/FlagSet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Hash.h
+++ b/Source/Urho3D/Container/Hash.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/HashBase.cpp
+++ b/Source/Urho3D/Container/HashBase.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/HashBase.h
+++ b/Source/Urho3D/Container/HashBase.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/HashMap.h
+++ b/Source/Urho3D/Container/HashMap.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/HashSet.h
+++ b/Source/Urho3D/Container/HashSet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Iter.h
+++ b/Source/Urho3D/Container/Iter.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/LinkedList.h
+++ b/Source/Urho3D/Container/LinkedList.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/List.h
+++ b/Source/Urho3D/Container/List.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/ListBase.h
+++ b/Source/Urho3D/Container/ListBase.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Pair.h
+++ b/Source/Urho3D/Container/Pair.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Ptr.h
+++ b/Source/Urho3D/Container/Ptr.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/RefCounted.cpp
+++ b/Source/Urho3D/Container/RefCounted.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/RefCounted.h
+++ b/Source/Urho3D/Container/RefCounted.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Sort.h
+++ b/Source/Urho3D/Container/Sort.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Str.cpp
+++ b/Source/Urho3D/Container/Str.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/Str.h
+++ b/Source/Urho3D/Container/Str.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Swap.cpp
+++ b/Source/Urho3D/Container/Swap.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/Swap.h
+++ b/Source/Urho3D/Container/Swap.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Container/VectorBase.cpp
+++ b/Source/Urho3D/Container/VectorBase.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Container/VectorBase.h
+++ b/Source/Urho3D/Container/VectorBase.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Attribute.h
+++ b/Source/Urho3D/Core/Attribute.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Core/Condition.cpp
+++ b/Source/Urho3D/Core/Condition.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Condition.h
+++ b/Source/Urho3D/Core/Condition.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Context.h
+++ b/Source/Urho3D/Core/Context.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/CoreEvents.h
+++ b/Source/Urho3D/Core/CoreEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/EventProfiler.cpp
+++ b/Source/Urho3D/Core/EventProfiler.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/EventProfiler.h
+++ b/Source/Urho3D/Core/EventProfiler.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Main.h
+++ b/Source/Urho3D/Core/Main.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/MiniDump.cpp
+++ b/Source/Urho3D/Core/MiniDump.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #if defined(_MSC_VER) && defined(URHO3D_MINIDUMPS)

--- a/Source/Urho3D/Core/MiniDump.h
+++ b/Source/Urho3D/Core/MiniDump.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Mutex.cpp
+++ b/Source/Urho3D/Core/Mutex.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Mutex.h
+++ b/Source/Urho3D/Core/Mutex.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Object.cpp
+++ b/Source/Urho3D/Core/Object.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Object.h
+++ b/Source/Urho3D/Core/Object.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/ProcessUtils.cpp
+++ b/Source/Urho3D/Core/ProcessUtils.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/ProcessUtils.h
+++ b/Source/Urho3D/Core/ProcessUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Profiler.cpp
+++ b/Source/Urho3D/Core/Profiler.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Profiler.h
+++ b/Source/Urho3D/Core/Profiler.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Spline.cpp
+++ b/Source/Urho3D/Core/Spline.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Spline.h
+++ b/Source/Urho3D/Core/Spline.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Core/StringHashRegister.cpp
+++ b/Source/Urho3D/Core/StringHashRegister.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/StringHashRegister.h
+++ b/Source/Urho3D/Core/StringHashRegister.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/StringUtils.cpp
+++ b/Source/Urho3D/Core/StringUtils.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/StringUtils.h
+++ b/Source/Urho3D/Core/StringUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Thread.cpp
+++ b/Source/Urho3D/Core/Thread.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Thread.h
+++ b/Source/Urho3D/Core/Thread.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Timer.cpp
+++ b/Source/Urho3D/Core/Timer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Timer.h
+++ b/Source/Urho3D/Core/Timer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Core/Variant.cpp
+++ b/Source/Urho3D/Core/Variant.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/Variant.h
+++ b/Source/Urho3D/Core/Variant.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Core/WorkQueue.cpp
+++ b/Source/Urho3D/Core/WorkQueue.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Core/WorkQueue.h
+++ b/Source/Urho3D/Core/WorkQueue.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/Database.cpp
+++ b/Source/Urho3D/Database/Database.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Database/Database.h
+++ b/Source/Urho3D/Database/Database.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Database/DatabaseEvents.h
+++ b/Source/Urho3D/Database/DatabaseEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/DbConnection.h
+++ b/Source/Urho3D/Database/DbConnection.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/DbResult.h
+++ b/Source/Urho3D/Database/DbResult.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/ODBC/ODBCConnection.cpp
+++ b/Source/Urho3D/Database/ODBC/ODBCConnection.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/Database/ODBC/ODBCConnection.h
+++ b/Source/Urho3D/Database/ODBC/ODBCConnection.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/ODBC/ODBCResult.h
+++ b/Source/Urho3D/Database/ODBC/ODBCResult.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
+++ b/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/Database/SQLite/SQLiteConnection.h
+++ b/Source/Urho3D/Database/SQLite/SQLiteConnection.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Database/SQLite/SQLiteResult.h
+++ b/Source/Urho3D/Database/SQLite/SQLiteResult.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/DebugNew.h
+++ b/Source/Urho3D/DebugNew.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // This file overrides global new to provide file and line information to allocations for easier memory leak detection on MSVC

--- a/Source/Urho3D/Engine/Application.cpp
+++ b/Source/Urho3D/Engine/Application.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Engine/Application.h
+++ b/Source/Urho3D/Engine/Application.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Engine/Console.cpp
+++ b/Source/Urho3D/Engine/Console.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Engine/Console.h
+++ b/Source/Urho3D/Engine/Console.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Engine/DebugHud.cpp
+++ b/Source/Urho3D/Engine/DebugHud.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Engine/DebugHud.h
+++ b/Source/Urho3D/Engine/DebugHud.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Engine/EngineDefs.h
+++ b/Source/Urho3D/Engine/EngineDefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Engine/EngineEvents.h
+++ b/Source/Urho3D/Engine/EngineEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Engine/WinWrapped.h
+++ b/Source/Urho3D/Engine/WinWrapped.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/AnimatedModel.h
+++ b/Source/Urho3D/Graphics/AnimatedModel.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Animation.cpp
+++ b/Source/Urho3D/Graphics/Animation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Animation.h
+++ b/Source/Urho3D/Graphics/Animation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/AnimationController.cpp
+++ b/Source/Urho3D/Graphics/AnimationController.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/AnimationController.h
+++ b/Source/Urho3D/Graphics/AnimationController.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/AnimationState.cpp
+++ b/Source/Urho3D/Graphics/AnimationState.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/AnimationState.h
+++ b/Source/Urho3D/Graphics/AnimationState.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Batch.cpp
+++ b/Source/Urho3D/Graphics/Batch.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Batch.h
+++ b/Source/Urho3D/Graphics/Batch.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/BillboardSet.h
+++ b/Source/Urho3D/Graphics/BillboardSet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Camera.cpp
+++ b/Source/Urho3D/Graphics/Camera.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Camera.h
+++ b/Source/Urho3D/Graphics/Camera.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/CustomGeometry.cpp
+++ b/Source/Urho3D/Graphics/CustomGeometry.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/CustomGeometry.h
+++ b/Source/Urho3D/Graphics/CustomGeometry.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/DebugRenderer.cpp
+++ b/Source/Urho3D/Graphics/DebugRenderer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/DebugRenderer.h
+++ b/Source/Urho3D/Graphics/DebugRenderer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/DecalSet.cpp
+++ b/Source/Urho3D/Graphics/DecalSet.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/DecalSet.h
+++ b/Source/Urho3D/Graphics/DecalSet.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/DrawableEvents.h
+++ b/Source/Urho3D/Graphics/DrawableEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Geometry.cpp
+++ b/Source/Urho3D/Graphics/Geometry.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Geometry.h
+++ b/Source/Urho3D/Graphics/Geometry.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Graphics.h
+++ b/Source/Urho3D/Graphics/Graphics.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/GraphicsEvents.h
+++ b/Source/Urho3D/Graphics/GraphicsEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Light.cpp
+++ b/Source/Urho3D/Graphics/Light.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Light.h
+++ b/Source/Urho3D/Graphics/Light.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Material.h
+++ b/Source/Urho3D/Graphics/Material.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Model.cpp
+++ b/Source/Urho3D/Graphics/Model.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Model.h
+++ b/Source/Urho3D/Graphics/Model.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/OcclusionBuffer.cpp
+++ b/Source/Urho3D/Graphics/OcclusionBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/OcclusionBuffer.h
+++ b/Source/Urho3D/Graphics/OcclusionBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Octree.cpp
+++ b/Source/Urho3D/Graphics/Octree.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Octree.h
+++ b/Source/Urho3D/Graphics/Octree.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/OctreeQuery.cpp
+++ b/Source/Urho3D/Graphics/OctreeQuery.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/ParticleEffect.cpp
+++ b/Source/Urho3D/Graphics/ParticleEffect.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/ParticleEffect.h
+++ b/Source/Urho3D/Graphics/ParticleEffect.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/ParticleEmitter.cpp
+++ b/Source/Urho3D/Graphics/ParticleEmitter.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/ParticleEmitter.h
+++ b/Source/Urho3D/Graphics/ParticleEmitter.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/RenderPath.cpp
+++ b/Source/Urho3D/Graphics/RenderPath.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/RenderPath.h
+++ b/Source/Urho3D/Graphics/RenderPath.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Renderer.h
+++ b/Source/Urho3D/Graphics/Renderer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/RibbonTrail.cpp
+++ b/Source/Urho3D/Graphics/RibbonTrail.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/RibbonTrail.h
+++ b/Source/Urho3D/Graphics/RibbonTrail.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Skeleton.cpp
+++ b/Source/Urho3D/Graphics/Skeleton.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Skeleton.h
+++ b/Source/Urho3D/Graphics/Skeleton.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Skybox.cpp
+++ b/Source/Urho3D/Graphics/Skybox.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Skybox.h
+++ b/Source/Urho3D/Graphics/Skybox.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/SpriteBatch.cpp
+++ b/Source/Urho3D/Graphics/SpriteBatch.cpp
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "SpriteBatch.h"

--- a/Source/Urho3D/Graphics/SpriteBatch.h
+++ b/Source/Urho3D/Graphics/SpriteBatch.h
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // Работает в двух режимах - рендеринг фигур и рендеринг спрайтов.

--- a/Source/Urho3D/Graphics/SpriteBatchBase.cpp
+++ b/Source/Urho3D/Graphics/SpriteBatchBase.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "SpriteBatchBase.h"

--- a/Source/Urho3D/Graphics/SpriteBatchBase.h
+++ b/Source/Urho3D/Graphics/SpriteBatchBase.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // Класс SpriteBatch разбит на части для более легкого восприятия кода

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/StaticModel.h
+++ b/Source/Urho3D/Graphics/StaticModel.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/StaticModelGroup.cpp
+++ b/Source/Urho3D/Graphics/StaticModelGroup.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/StaticModelGroup.h
+++ b/Source/Urho3D/Graphics/StaticModelGroup.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Tangent.cpp
+++ b/Source/Urho3D/Graphics/Tangent.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Tangent.h
+++ b/Source/Urho3D/Graphics/Tangent.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Technique.cpp
+++ b/Source/Urho3D/Graphics/Technique.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Technique.h
+++ b/Source/Urho3D/Graphics/Technique.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Graphics/Terrain.cpp
+++ b/Source/Urho3D/Graphics/Terrain.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Terrain.h
+++ b/Source/Urho3D/Graphics/Terrain.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/TerrainPatch.cpp
+++ b/Source/Urho3D/Graphics/TerrainPatch.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/TerrainPatch.h
+++ b/Source/Urho3D/Graphics/TerrainPatch.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/View.h
+++ b/Source/Urho3D/Graphics/View.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Viewport.cpp
+++ b/Source/Urho3D/Graphics/Viewport.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Viewport.h
+++ b/Source/Urho3D/Graphics/Viewport.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Graphics/Zone.cpp
+++ b/Source/Urho3D/Graphics/Zone.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Graphics/Zone.h
+++ b/Source/Urho3D/Graphics/Zone.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/ConstantBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/ConstantBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/ConstantBuffer.h
+++ b/Source/Urho3D/GraphicsAPI/ConstantBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ConstantBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ConstantBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.h
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11IndexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11IndexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11RenderSurface.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11RenderSurface.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderProgram.h
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderProgram.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture2D.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture2DArray.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture2DArray.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture3D.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Texture3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11TextureCube.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11TextureCube.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.h
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/ForceDiscreteGPU.cpp
+++ b/Source/Urho3D/GraphicsAPI/ForceDiscreteGPU.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // Prefer the high-performance GPU on switchable GPU systems

--- a/Source/Urho3D/GraphicsAPI/GPUObject.cpp
+++ b/Source/Urho3D/GraphicsAPI/GPUObject.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/GPUObject.h
+++ b/Source/Urho3D/GraphicsAPI/GPUObject.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/GraphicsDefs.cpp
+++ b/Source/Urho3D/GraphicsAPI/GraphicsDefs.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/GraphicsDefs.h
+++ b/Source/Urho3D/GraphicsAPI/GraphicsDefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/GraphicsAPI/GraphicsImpl.h
+++ b/Source/Urho3D/GraphicsAPI/GraphicsImpl.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/IndexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/IndexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // This file contains IndexBuffer code common to all graphics APIs.

--- a/Source/Urho3D/GraphicsAPI/IndexBuffer.h
+++ b/Source/Urho3D/GraphicsAPI/IndexBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLConstantBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLConstantBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphicsImpl.h
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphicsImpl.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLIndexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLIndexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLRenderSurface.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLRenderSurface.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderProgram.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderProgram.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderProgram.h
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderProgram.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLShaderVariation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture2D.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture2DArray.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture2DArray.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture3D.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLTexture3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLTextureCube.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLTextureCube.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLVertexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLVertexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/RenderSurface.cpp
+++ b/Source/Urho3D/GraphicsAPI/RenderSurface.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/RenderSurface.h
+++ b/Source/Urho3D/GraphicsAPI/RenderSurface.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Shader.cpp
+++ b/Source/Urho3D/GraphicsAPI/Shader.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Shader.h
+++ b/Source/Urho3D/GraphicsAPI/Shader.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/ShaderPrecache.cpp
+++ b/Source/Urho3D/GraphicsAPI/ShaderPrecache.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/ShaderPrecache.h
+++ b/Source/Urho3D/GraphicsAPI/ShaderPrecache.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/ShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/ShaderVariation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/ShaderVariation.h
+++ b/Source/Urho3D/GraphicsAPI/ShaderVariation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Texture.cpp
+++ b/Source/Urho3D/GraphicsAPI/Texture.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Texture.h
+++ b/Source/Urho3D/GraphicsAPI/Texture.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Texture2D.cpp
+++ b/Source/Urho3D/GraphicsAPI/Texture2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Texture2D.h
+++ b/Source/Urho3D/GraphicsAPI/Texture2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Texture2DArray.cpp
+++ b/Source/Urho3D/GraphicsAPI/Texture2DArray.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Texture2DArray.h
+++ b/Source/Urho3D/GraphicsAPI/Texture2DArray.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/Texture3D.cpp
+++ b/Source/Urho3D/GraphicsAPI/Texture3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/Texture3D.h
+++ b/Source/Urho3D/GraphicsAPI/Texture3D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/TextureCube.cpp
+++ b/Source/Urho3D/GraphicsAPI/TextureCube.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/GraphicsAPI/TextureCube.h
+++ b/Source/Urho3D/GraphicsAPI/TextureCube.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/GraphicsAPI/VertexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/VertexBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 // This file contains VertexBuffer code common to all graphics APIs.

--- a/Source/Urho3D/GraphicsAPI/VertexBuffer.h
+++ b/Source/Urho3D/GraphicsAPI/VertexBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IK/IK.cpp
+++ b/Source/Urho3D/IK/IK.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../IK/IK.h"

--- a/Source/Urho3D/IK/IK.h
+++ b/Source/Urho3D/IK/IK.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /*

--- a/Source/Urho3D/IK/IKConstraint.cpp
+++ b/Source/Urho3D/IK/IKConstraint.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Core/Context.h"

--- a/Source/Urho3D/IK/IKConstraint.h
+++ b/Source/Urho3D/IK/IKConstraint.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IK/IKConverters.cpp
+++ b/Source/Urho3D/IK/IKConverters.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../IK/IKConverters.h"

--- a/Source/Urho3D/IK/IKConverters.h
+++ b/Source/Urho3D/IK/IKConverters.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/IK/IKEffector.cpp
+++ b/Source/Urho3D/IK/IKEffector.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Core/Context.h"

--- a/Source/Urho3D/IK/IKEffector.h
+++ b/Source/Urho3D/IK/IKEffector.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IK/IKEvents.h
+++ b/Source/Urho3D/IK/IKEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IK/IKSolver.cpp
+++ b/Source/Urho3D/IK/IKSolver.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../IK/IKSolver.h"

--- a/Source/Urho3D/IK/IKSolver.h
+++ b/Source/Urho3D/IK/IKSolver.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/AbstractFile.h
+++ b/Source/Urho3D/IO/AbstractFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/Compression.cpp
+++ b/Source/Urho3D/IO/Compression.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/Compression.h
+++ b/Source/Urho3D/IO/Compression.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/Deserializer.cpp
+++ b/Source/Urho3D/IO/Deserializer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/Deserializer.h
+++ b/Source/Urho3D/IO/Deserializer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/File.cpp
+++ b/Source/Urho3D/IO/File.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/FileSystem.h
+++ b/Source/Urho3D/IO/FileSystem.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/FileWatcher.cpp
+++ b/Source/Urho3D/IO/FileWatcher.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/FileWatcher.h
+++ b/Source/Urho3D/IO/FileWatcher.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/IOEvents.h
+++ b/Source/Urho3D/IO/IOEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/Log.h
+++ b/Source/Urho3D/IO/Log.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/MacFileWatcher.h
+++ b/Source/Urho3D/IO/MacFileWatcher.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// Return true when the running OS has the specified version number or later.

--- a/Source/Urho3D/IO/MacFileWatcher.m
+++ b/Source/Urho3D/IO/MacFileWatcher.m
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #import <Foundation/Foundation.h>

--- a/Source/Urho3D/IO/MemoryBuffer.cpp
+++ b/Source/Urho3D/IO/MemoryBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/MemoryBuffer.h
+++ b/Source/Urho3D/IO/MemoryBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/NamedPipe.cpp
+++ b/Source/Urho3D/IO/NamedPipe.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/NamedPipe.h
+++ b/Source/Urho3D/IO/NamedPipe.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/PackageFile.cpp
+++ b/Source/Urho3D/IO/PackageFile.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/PackageFile.h
+++ b/Source/Urho3D/IO/PackageFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/RWOpsWrapper.h
+++ b/Source/Urho3D/IO/RWOpsWrapper.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/Serializer.cpp
+++ b/Source/Urho3D/IO/Serializer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/Serializer.h
+++ b/Source/Urho3D/IO/Serializer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/IO/VectorBuffer.cpp
+++ b/Source/Urho3D/IO/VectorBuffer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/IO/VectorBuffer.h
+++ b/Source/Urho3D/IO/VectorBuffer.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Input/Controls.cpp
+++ b/Source/Urho3D/Input/Controls.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Input/Controls.h
+++ b/Source/Urho3D/Input/Controls.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Input/InputConstants.h
+++ b/Source/Urho3D/Input/InputConstants.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Input/InputEvents.h
+++ b/Source/Urho3D/Input/InputEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/LibraryInfo.cpp
+++ b/Source/Urho3D/LibraryInfo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "Precompiled.h"

--- a/Source/Urho3D/LibraryInfo.h
+++ b/Source/Urho3D/LibraryInfo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/AreaAllocator.cpp
+++ b/Source/Urho3D/Math/AreaAllocator.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/AreaAllocator.h
+++ b/Source/Urho3D/Math/AreaAllocator.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/BigInt.cpp
+++ b/Source/Urho3D/Math/BigInt.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "BigInt.h"

--- a/Source/Urho3D/Math/BigInt.h
+++ b/Source/Urho3D/Math/BigInt.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/BoundingBox.cpp
+++ b/Source/Urho3D/Math/BoundingBox.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/BoundingBox.h
+++ b/Source/Urho3D/Math/BoundingBox.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Color.cpp
+++ b/Source/Urho3D/Math/Color.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Color.h
+++ b/Source/Urho3D/Math/Color.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Frustum.cpp
+++ b/Source/Urho3D/Math/Frustum.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Frustum.h
+++ b/Source/Urho3D/Math/Frustum.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Math/MathDefs.cpp
+++ b/Source/Urho3D/Math/MathDefs.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/MathDefs.h
+++ b/Source/Urho3D/Math/MathDefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Math/Matrix2.cpp
+++ b/Source/Urho3D/Math/Matrix2.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Matrix2.h
+++ b/Source/Urho3D/Math/Matrix2.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Matrix3.cpp
+++ b/Source/Urho3D/Math/Matrix3.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Matrix3.h
+++ b/Source/Urho3D/Math/Matrix3.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Matrix3x4.cpp
+++ b/Source/Urho3D/Math/Matrix3x4.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Matrix3x4.h
+++ b/Source/Urho3D/Math/Matrix3x4.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Matrix4.cpp
+++ b/Source/Urho3D/Math/Matrix4.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Matrix4.h
+++ b/Source/Urho3D/Math/Matrix4.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Plane.cpp
+++ b/Source/Urho3D/Math/Plane.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Plane.h
+++ b/Source/Urho3D/Math/Plane.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Polyhedron.cpp
+++ b/Source/Urho3D/Math/Polyhedron.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Polyhedron.h
+++ b/Source/Urho3D/Math/Polyhedron.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Quaternion.cpp
+++ b/Source/Urho3D/Math/Quaternion.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Quaternion.h
+++ b/Source/Urho3D/Math/Quaternion.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Random.cpp
+++ b/Source/Urho3D/Math/Random.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Random.h
+++ b/Source/Urho3D/Math/Random.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Ray.cpp
+++ b/Source/Urho3D/Math/Ray.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Ray.h
+++ b/Source/Urho3D/Math/Ray.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Rect.cpp
+++ b/Source/Urho3D/Math/Rect.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Rect.h
+++ b/Source/Urho3D/Math/Rect.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Sphere.cpp
+++ b/Source/Urho3D/Math/Sphere.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Sphere.h
+++ b/Source/Urho3D/Math/Sphere.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/StringHash.cpp
+++ b/Source/Urho3D/Math/StringHash.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/StringHash.h
+++ b/Source/Urho3D/Math/StringHash.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Vector2.cpp
+++ b/Source/Urho3D/Math/Vector2.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Vector2.h
+++ b/Source/Urho3D/Math/Vector2.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Vector3.cpp
+++ b/Source/Urho3D/Math/Vector3.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Vector3.h
+++ b/Source/Urho3D/Math/Vector3.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Math/Vector4.cpp
+++ b/Source/Urho3D/Math/Vector4.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Math/Vector4.h
+++ b/Source/Urho3D/Math/Vector4.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/CrowdAgent.cpp
+++ b/Source/Urho3D/Navigation/CrowdAgent.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/CrowdAgent.h
+++ b/Source/Urho3D/Navigation/CrowdAgent.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Navigation/CrowdManager.cpp
+++ b/Source/Urho3D/Navigation/CrowdManager.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/CrowdManager.h
+++ b/Source/Urho3D/Navigation/CrowdManager.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.h
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/NavArea.cpp
+++ b/Source/Urho3D/Navigation/NavArea.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/NavArea.h
+++ b/Source/Urho3D/Navigation/NavArea.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/NavBuildData.cpp
+++ b/Source/Urho3D/Navigation/NavBuildData.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/NavBuildData.h
+++ b/Source/Urho3D/Navigation/NavBuildData.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/Navigable.cpp
+++ b/Source/Urho3D/Navigation/Navigable.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/Navigable.h
+++ b/Source/Urho3D/Navigation/Navigable.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/NavigationEvents.h
+++ b/Source/Urho3D/Navigation/NavigationEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Navigation/Obstacle.cpp
+++ b/Source/Urho3D/Navigation/Obstacle.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/Obstacle.h
+++ b/Source/Urho3D/Navigation/Obstacle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Navigation/OffMeshConnection.cpp
+++ b/Source/Urho3D/Navigation/OffMeshConnection.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Navigation/OffMeshConnection.h
+++ b/Source/Urho3D/Navigation/OffMeshConnection.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Network/HttpRequest.cpp
+++ b/Source/Urho3D/Network/HttpRequest.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Network/HttpRequest.h
+++ b/Source/Urho3D/Network/HttpRequest.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Network/Network.cpp
+++ b/Source/Urho3D/Network/Network.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Network/Network.h
+++ b/Source/Urho3D/Network/Network.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Network/NetworkEvents.h
+++ b/Source/Urho3D/Network/NetworkEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Network/NetworkPriority.cpp
+++ b/Source/Urho3D/Network/NetworkPriority.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Network/NetworkPriority.h
+++ b/Source/Urho3D/Network/NetworkPriority.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Network/Protocol.h
+++ b/Source/Urho3D/Network/Protocol.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics/CollisionShape.cpp
+++ b/Source/Urho3D/Physics/CollisionShape.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Physics/Constraint.cpp
+++ b/Source/Urho3D/Physics/Constraint.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics/Constraint.h
+++ b/Source/Urho3D/Physics/Constraint.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Physics/PhysicsEvents.h
+++ b/Source/Urho3D/Physics/PhysicsEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics/PhysicsUtils.h
+++ b/Source/Urho3D/Physics/PhysicsUtils.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics/RaycastVehicle.cpp
+++ b/Source/Urho3D/Physics/RaycastVehicle.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Core/Context.h"

--- a/Source/Urho3D/Physics/RaycastVehicle.h
+++ b/Source/Urho3D/Physics/RaycastVehicle.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics/RigidBody.cpp
+++ b/Source/Urho3D/Physics/RigidBody.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics/RigidBody.h
+++ b/Source/Urho3D/Physics/RigidBody.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Physics2D/CollisionBox2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionBox2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionBox2D.h
+++ b/Source/Urho3D/Physics2D/CollisionBox2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/CollisionChain2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionChain2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionChain2D.h
+++ b/Source/Urho3D/Physics2D/CollisionChain2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/CollisionCircle2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionCircle2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionCircle2D.h
+++ b/Source/Urho3D/Physics2D/CollisionCircle2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/CollisionEdge2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionEdge2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionEdge2D.h
+++ b/Source/Urho3D/Physics2D/CollisionEdge2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/CollisionPolygon2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionPolygon2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionPolygon2D.h
+++ b/Source/Urho3D/Physics2D/CollisionPolygon2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/CollisionShape2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionShape2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/CollisionShape2D.h
+++ b/Source/Urho3D/Physics2D/CollisionShape2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/Constraint2D.cpp
+++ b/Source/Urho3D/Physics2D/Constraint2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/Constraint2D.h
+++ b/Source/Urho3D/Physics2D/Constraint2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintDistance2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintDistance2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintDistance2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintDistance2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintFriction2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintFriction2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintFriction2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintFriction2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintGear2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintGear2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintGear2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintGear2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintMotor2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintMotor2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintMotor2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintMotor2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintMouse2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintMouse2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintMouse2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintMouse2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintPrismatic2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintPrismatic2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintPrismatic2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintPrismatic2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintPulley2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintPulley2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintPulley2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintPulley2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintRevolute2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintRevolute2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintRevolute2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintRevolute2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintWeld2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintWeld2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintWeld2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintWeld2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/ConstraintWheel2D.cpp
+++ b/Source/Urho3D/Physics2D/ConstraintWheel2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/ConstraintWheel2D.h
+++ b/Source/Urho3D/Physics2D/ConstraintWheel2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/Physics2D.cpp
+++ b/Source/Urho3D/Physics2D/Physics2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/Physics2D.h
+++ b/Source/Urho3D/Physics2D/Physics2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/PhysicsEvents2D.h
+++ b/Source/Urho3D/Physics2D/PhysicsEvents2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/PhysicsUtils2D.h
+++ b/Source/Urho3D/Physics2D/PhysicsUtils2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Physics2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Physics2D/PhysicsWorld2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Physics2D/PhysicsWorld2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Physics2D/RigidBody2D.cpp
+++ b/Source/Urho3D/Physics2D/RigidBody2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Physics2D/RigidBody2D.h
+++ b/Source/Urho3D/Physics2D/RigidBody2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Precompiled.h
+++ b/Source/Urho3D/Precompiled.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef __cplusplus

--- a/Source/Urho3D/Resource/BackgroundLoader.cpp
+++ b/Source/Urho3D/Resource/BackgroundLoader.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #ifdef URHO3D_THREADING

--- a/Source/Urho3D/Resource/BackgroundLoader.h
+++ b/Source/Urho3D/Resource/BackgroundLoader.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/Decompress.cpp
+++ b/Source/Urho3D/Resource/Decompress.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/Decompress.h
+++ b/Source/Urho3D/Resource/Decompress.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Resource/JSONFile.cpp
+++ b/Source/Urho3D/Resource/JSONFile.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/JSONFile.h
+++ b/Source/Urho3D/Resource/JSONFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/JSONValue.cpp
+++ b/Source/Urho3D/Resource/JSONValue.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Resource/Localization.cpp
+++ b/Source/Urho3D/Resource/Localization.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/Localization.h
+++ b/Source/Urho3D/Resource/Localization.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/PListFile.cpp
+++ b/Source/Urho3D/Resource/PListFile.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/PListFile.h
+++ b/Source/Urho3D/Resource/PListFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/Resource.h
+++ b/Source/Urho3D/Resource/Resource.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Resource/ResourceEvents.h
+++ b/Source/Urho3D/Resource/ResourceEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/XMLElement.cpp
+++ b/Source/Urho3D/Resource/XMLElement.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/XMLElement.h
+++ b/Source/Urho3D/Resource/XMLElement.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Resource/XMLFile.cpp
+++ b/Source/Urho3D/Resource/XMLFile.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Resource/XMLFile.h
+++ b/Source/Urho3D/Resource/XMLFile.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/Animatable.cpp
+++ b/Source/Urho3D/Scene/Animatable.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/Animatable.h
+++ b/Source/Urho3D/Scene/Animatable.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/AnimationDefs.h
+++ b/Source/Urho3D/Scene/AnimationDefs.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/Component.cpp
+++ b/Source/Urho3D/Scene/Component.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/Component.h
+++ b/Source/Urho3D/Scene/Component.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/LogicComponent.cpp
+++ b/Source/Urho3D/Scene/LogicComponent.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/LogicComponent.h
+++ b/Source/Urho3D/Scene/LogicComponent.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/ObjectAnimation.cpp
+++ b/Source/Urho3D/Scene/ObjectAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/ObjectAnimation.h
+++ b/Source/Urho3D/Scene/ObjectAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/ReplicationState.h
+++ b/Source/Urho3D/Scene/ReplicationState.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/SceneEvents.h
+++ b/Source/Urho3D/Scene/SceneEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/SceneResolver.cpp
+++ b/Source/Urho3D/Scene/SceneResolver.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/SceneResolver.h
+++ b/Source/Urho3D/Scene/SceneResolver.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/Serializable.cpp
+++ b/Source/Urho3D/Scene/Serializable.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/Serializable.h
+++ b/Source/Urho3D/Scene/Serializable.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/SmoothedTransform.cpp
+++ b/Source/Urho3D/Scene/SmoothedTransform.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/SmoothedTransform.h
+++ b/Source/Urho3D/Scene/SmoothedTransform.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/SplinePath.cpp
+++ b/Source/Urho3D/Scene/SplinePath.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/SplinePath.h
+++ b/Source/Urho3D/Scene/SplinePath.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/UnknownComponent.cpp
+++ b/Source/Urho3D/Scene/UnknownComponent.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/UnknownComponent.h
+++ b/Source/Urho3D/Scene/UnknownComponent.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Scene/ValueAnimation.cpp
+++ b/Source/Urho3D/Scene/ValueAnimation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/ValueAnimation.h
+++ b/Source/Urho3D/Scene/ValueAnimation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Scene/ValueAnimationInfo.cpp
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Scene/ValueAnimationInfo.h
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/BorderImage.cpp
+++ b/Source/Urho3D/UI/BorderImage.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/BorderImage.h
+++ b/Source/Urho3D/UI/BorderImage.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Button.cpp
+++ b/Source/Urho3D/UI/Button.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Button.h
+++ b/Source/Urho3D/UI/Button.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/CheckBox.cpp
+++ b/Source/Urho3D/UI/CheckBox.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/CheckBox.h
+++ b/Source/Urho3D/UI/CheckBox.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Cursor.cpp
+++ b/Source/Urho3D/UI/Cursor.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Cursor.h
+++ b/Source/Urho3D/UI/Cursor.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/DropDownList.cpp
+++ b/Source/Urho3D/UI/DropDownList.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/DropDownList.h
+++ b/Source/Urho3D/UI/DropDownList.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/FileSelector.cpp
+++ b/Source/Urho3D/UI/FileSelector.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/FileSelector.h
+++ b/Source/Urho3D/UI/FileSelector.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Font.cpp
+++ b/Source/Urho3D/UI/Font.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Font.h
+++ b/Source/Urho3D/UI/Font.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/FontFace.cpp
+++ b/Source/Urho3D/UI/FontFace.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/FontFace.h
+++ b/Source/Urho3D/UI/FontFace.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/FontFaceBitmap.cpp
+++ b/Source/Urho3D/UI/FontFaceBitmap.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/FontFaceBitmap.h
+++ b/Source/Urho3D/UI/FontFaceBitmap.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/FontFaceFreeType.cpp
+++ b/Source/Urho3D/UI/FontFaceFreeType.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/FontFaceFreeType.h
+++ b/Source/Urho3D/UI/FontFaceFreeType.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/LineEdit.cpp
+++ b/Source/Urho3D/UI/LineEdit.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/LineEdit.h
+++ b/Source/Urho3D/UI/LineEdit.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/ListView.cpp
+++ b/Source/Urho3D/UI/ListView.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/ListView.h
+++ b/Source/Urho3D/UI/ListView.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/Menu.cpp
+++ b/Source/Urho3D/UI/Menu.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Menu.h
+++ b/Source/Urho3D/UI/Menu.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/MessageBox.cpp
+++ b/Source/Urho3D/UI/MessageBox.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/MessageBox.h
+++ b/Source/Urho3D/UI/MessageBox.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/ProgressBar.cpp
+++ b/Source/Urho3D/UI/ProgressBar.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/ProgressBar.h
+++ b/Source/Urho3D/UI/ProgressBar.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/ScrollBar.cpp
+++ b/Source/Urho3D/UI/ScrollBar.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/ScrollBar.h
+++ b/Source/Urho3D/UI/ScrollBar.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/ScrollView.cpp
+++ b/Source/Urho3D/UI/ScrollView.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/ScrollView.h
+++ b/Source/Urho3D/UI/ScrollView.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Slider.cpp
+++ b/Source/Urho3D/UI/Slider.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Slider.h
+++ b/Source/Urho3D/UI/Slider.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Sprite.cpp
+++ b/Source/Urho3D/UI/Sprite.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Sprite.h
+++ b/Source/Urho3D/UI/Sprite.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Text.h
+++ b/Source/Urho3D/UI/Text.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/Text3D.cpp
+++ b/Source/Urho3D/UI/Text3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Text3D.h
+++ b/Source/Urho3D/UI/Text3D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/ToolTip.cpp
+++ b/Source/Urho3D/UI/ToolTip.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/ToolTip.h
+++ b/Source/Urho3D/UI/ToolTip.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/UIBatch.cpp
+++ b/Source/Urho3D/UI/UIBatch.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/UIBatch.h
+++ b/Source/Urho3D/UI/UIBatch.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/UIComponent.cpp
+++ b/Source/Urho3D/UI/UIComponent.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/UIComponent.h
+++ b/Source/Urho3D/UI/UIComponent.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/UIElement.cpp
+++ b/Source/Urho3D/UI/UIElement.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/UI/UIEvents.h
+++ b/Source/Urho3D/UI/UIEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/UISelectable.cpp
+++ b/Source/Urho3D/UI/UISelectable.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/UISelectable.h
+++ b/Source/Urho3D/UI/UISelectable.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/View3D.cpp
+++ b/Source/Urho3D/UI/View3D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/View3D.h
+++ b/Source/Urho3D/UI/View3D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/UI/Window.cpp
+++ b/Source/Urho3D/UI/Window.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/UI/Window.h
+++ b/Source/Urho3D/UI/Window.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.h
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/AnimationSet2D.h
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/Drawable2D.cpp
+++ b/Source/Urho3D/Urho2D/Drawable2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/Drawable2D.h
+++ b/Source/Urho3D/Urho2D/Drawable2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/ParticleEffect2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/Renderer2D.cpp
+++ b/Source/Urho3D/Urho2D/Renderer2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/Renderer2D.h
+++ b/Source/Urho3D/Urho2D/Renderer2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/Sprite2D.cpp
+++ b/Source/Urho3D/Urho2D/Sprite2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/Sprite2D.h
+++ b/Source/Urho3D/Urho2D/Sprite2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/SpriteSheet2D.cpp
+++ b/Source/Urho3D/Urho2D/SpriteSheet2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/SpriteSheet2D.h
+++ b/Source/Urho3D/Urho2D/SpriteSheet2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/SpriterData2D.cpp
+++ b/Source/Urho3D/Urho2D/SpriterData2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/SpriterData2D.h
+++ b/Source/Urho3D/Urho2D/SpriterData2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/SpriterInstance2D.cpp
+++ b/Source/Urho3D/Urho2D/SpriterInstance2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/SpriterInstance2D.h
+++ b/Source/Urho3D/Urho2D/SpriterInstance2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/StaticSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/StaticSprite2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/StaticSprite2D.h
+++ b/Source/Urho3D/Urho2D/StaticSprite2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/StretchableSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/StretchableSprite2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/StretchableSprite2D.h
+++ b/Source/Urho3D/Urho2D/StretchableSprite2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/TileMap2D.h
+++ b/Source/Urho3D/Urho2D/TileMap2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.h
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 /// \file

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.h
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/Urho2D.cpp
+++ b/Source/Urho3D/Urho2D/Urho2D.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include "../Precompiled.h"

--- a/Source/Urho3D/Urho2D/Urho2D.h
+++ b/Source/Urho3D/Urho2D/Urho2D.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho2D/Urho2DEvents.h
+++ b/Source/Urho3D/Urho2D/Urho2DEvents.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho3D.pc.in
+++ b/Source/Urho3D/Urho3D.pc.in
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 prefix=@CMAKE_INSTALL_PREFIX@

--- a/Source/Urho3D/Urho3DAll.h.in
+++ b/Source/Urho3D/Urho3DAll.h.in
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/Source/Urho3D/Urho3DConfig.h
+++ b/Source/Urho3D/Urho3DConfig.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #pragma once

--- a/android/launcher-app/CMakeLists.txt
+++ b/android/launcher-app/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Set CMake minimum version

--- a/android/launcher-app/build.gradle.kts
+++ b/android/launcher-app/build.gradle.kts
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 plugins {

--- a/android/launcher-app/src/main/java/io/urho3d/launcher/LauncherActivity.kt
+++ b/android/launcher-app/src/main/java/io/urho3d/launcher/LauncherActivity.kt
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 package io.urho3d.launcher

--- a/android/launcher-app/src/main/java/io/urho3d/launcher/MainActivity.kt
+++ b/android/launcher-app/src/main/java/io/urho3d/launcher/MainActivity.kt
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 package io.urho3d.launcher

--- a/android/urho3d-lib/build.gradle.kts
+++ b/android/urho3d-lib/build.gradle.kts
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 import org.gradle.internal.io.NullOutputStream

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 import org.gradle.internal.io.NullOutputStream

--- a/cmake/Modules/AdjustPkgConfigForMSVC.cmake
+++ b/cmake/Modules/AdjustPkgConfigForMSVC.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # VS generator is multi-config, we need to use the CMake generator expression to get the correct target linker filename during post build step

--- a/cmake/Modules/CheckCompilerToolchain.cmake
+++ b/cmake/Modules/CheckCompilerToolchain.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Check the chosen compiler toolchain in the build tree

--- a/cmake/Modules/CheckHost.cmake
+++ b/cmake/Modules/CheckHost.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Check the capability of the host system

--- a/cmake/Modules/CheckUrhoLibrary.cpp
+++ b/cmake/Modules/CheckUrhoLibrary.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 #include <Urho3D/LibraryInfo.h>

--- a/cmake/Modules/FindDRM.cmake
+++ b/cmake/Modules/FindDRM.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Direct Rendering Manager development library

--- a/cmake/Modules/FindDirectFB.cmake
+++ b/cmake/Modules/FindDirectFB.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find DirectFB development library

--- a/cmake/Modules/FindDirectX.cmake
+++ b/cmake/Modules/FindDirectX.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # For MSVC compiler, find Microsoft DirectX installation in Windows SDK or in June 2010 DirectX SDK or later

--- a/cmake/Modules/FindEsound.cmake
+++ b/cmake/Modules/FindEsound.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Esound development library

--- a/cmake/Modules/FindFusionSound.cmake
+++ b/cmake/Modules/FindFusionSound.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find FusionSound development library

--- a/cmake/Modules/FindGBM.cmake
+++ b/cmake/Modules/FindGBM.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Generic Buffer Management development library

--- a/cmake/Modules/FindJack.cmake
+++ b/cmake/Modules/FindJack.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Jack Audio Connection Kit development library

--- a/cmake/Modules/FindNAS.cmake
+++ b/cmake/Modules/FindNAS.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find NetworkAudioSystem development library

--- a/cmake/Modules/FindODBC.cmake
+++ b/cmake/Modules/FindODBC.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find ODBC driver manager

--- a/cmake/Modules/FindOSS.cmake
+++ b/cmake/Modules/FindOSS.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Open Sound System development library

--- a/cmake/Modules/FindPulseAudio.cmake
+++ b/cmake/Modules/FindPulseAudio.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find PulseAudio development library

--- a/cmake/Modules/FindReadline.cmake
+++ b/cmake/Modules/FindReadline.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Readline development library

--- a/cmake/Modules/FindSNDIO.cmake
+++ b/cmake/Modules/FindSNDIO.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find RoarAudio development library

--- a/cmake/Modules/FindSecretRabbitCode.cmake
+++ b/cmake/Modules/FindSecretRabbitCode.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Secret Rabbit Code development library

--- a/cmake/Modules/FindUrho3D.cmake
+++ b/cmake/Modules/FindUrho3D.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Urho3D include directories and libraries in the Urho3D SDK installation or build tree or in Android library

--- a/cmake/Modules/FindVideoCore.cmake
+++ b/cmake/Modules/FindVideoCore.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Broadcom VideoCore firmware installation

--- a/cmake/Modules/FindWayland.cmake
+++ b/cmake/Modules/FindWayland.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find Wayland display server

--- a/cmake/Modules/FindaRts.cmake
+++ b/cmake/Modules/FindaRts.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Find aRts development library

--- a/cmake/Modules/GetUrhoRevision.cmake
+++ b/cmake/Modules/GetUrhoRevision.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Get Urho3D library revision number

--- a/cmake/Modules/UrhoCommon.cmake
+++ b/cmake/Modules/UrhoCommon.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Save the initial values of CC and CXX environment variables

--- a/cmake/Toolchains/Arm.cmake
+++ b/cmake/Toolchains/Arm.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Workaround try_compile() limitation where it cannot yet see cache variables during initial configuration

--- a/cmake/Toolchains/MinGW.cmake
+++ b/cmake/Toolchains/MinGW.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html

--- a/cmake/Toolchains/RaspberryPi.cmake
+++ b/cmake/Toolchains/RaspberryPi.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Workaround try_compile() limitation where it cannot yet see cache variables during initial configuration

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Project-wide Gradle settings.

--- a/rakefile
+++ b/rakefile
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 task default: :build

--- a/script/.bash_helpers.sh
+++ b/script/.bash_helpers.sh
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Define helpers

--- a/script/cmake_arm.sh
+++ b/script/cmake_arm.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -D ARM=1

--- a/script/cmake_clean.sh
+++ b/script/cmake_clean.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Clean the CMake cache and CMake generated files in the build tree

--- a/script/cmake_codeblocks.sh
+++ b/script/cmake_codeblocks.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G "CodeBlocks - Unix Makefiles"

--- a/script/cmake_codelite.sh
+++ b/script/cmake_codelite.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G "CodeLite - Unix Makefiles"

--- a/script/cmake_emscripten.sh
+++ b/script/cmake_emscripten.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -D WEB=1

--- a/script/cmake_generic.sh
+++ b/script/cmake_generic.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 # Determine source tree and build tree

--- a/script/cmake_ios.sh
+++ b/script/cmake_ios.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G Xcode -D IOS=1 -T buildsystem=1

--- a/script/cmake_mingw.sh
+++ b/script/cmake_mingw.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -D MINGW=1

--- a/script/cmake_ninja.sh
+++ b/script/cmake_ninja.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G "Ninja"

--- a/script/cmake_rpi.sh
+++ b/script/cmake_rpi.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -D RPI=1

--- a/script/cmake_tvos.sh
+++ b/script/cmake_tvos.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G Xcode -D TVOS=1 -T buildsystem=1

--- a/script/cmake_xcode.sh
+++ b/script/cmake_xcode.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 $(dirname $0)/cmake_generic.sh "$@" -G Xcode -T buildsystem=1

--- a/script/dockerized.sh
+++ b/script/dockerized.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if [[ $# -eq 0 ]]; then echo "Usage: dockerized.sh linux|mingw|android|rpi|arm|web [command]"; exit 1; fi

--- a/script/test_tools.sh
+++ b/script/test_tools.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2008-2022 the Urho3D project
+# Copyright (c) 2022-2022 the Dviglo project
 # License: MIT
 
 if [[ $# != 2 ]]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2022 the Urho3D project
+// Copyright (c) 2022-2022 the Dviglo project
 // License: MIT
 
 include(":android:urho3d-lib", ":android:launcher-app")


### PR DESCRIPTION
Выполнил с помощью sh-скрипта в Винде

```
# https://man7.org/linux/man-pages/man1/find.1.html
# 1) find ./repo/.github рекурсивно ищет в указанной папке
# 2) -type f указывает, что нам нужны только файлы, а папки в список добавлять не нужно
# 3) -exec выполняет команду для найденных файлов
# 4) {} + заменяется на список файлов, в котором файлы разделены пробелом

# https://perl101.org/command-line-switches.html
# 1) -e 'скрипт' означает, что нужно выполнить скрипт, переданный в команде
# 2) Комбинация -p и -i позволяет выполнить замену в переданном списке файлов

find ./repo -type f -exec perl -pi -e \
  's/(\/\/ Copyright \(c\) 2008-2022 the Urho3D project)(\r?\n)/'`
 `'$1$2\/\/ Copyright (c) 2022-2022 the Dviglo project$2/g' {} +

find ./repo -type f -exec perl -pi -e \
  's/(# Copyright \(c\) 2008-2022 the Urho3D project)(\r?\n)/'`
 `'$1$2# Copyright (c) 2022-2022 the Dviglo project$2/g' {} +

read -p "Нажмите Enter для продолжения..."
```
