### PR TITLE
.gitignore: Исправил игнор отслеживаемых файлов

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !/bin/**/
 !/bin/*.bat
 !/bin/*.sh
+!/bin/*.html
 /bin/*.app/
 /bin/*.app.dSYM/
 /bin/jit/
@@ -113,6 +114,7 @@ CTestTestfile.cmake
 
 # Misc.
 configure*
+!/Source/ThirdParty/SDL/src/hidapi/configure.ac
 *~
 *.swp
 .DS_Store


### PR DESCRIPTION
Если файл в репе отслеживался, а потом был добавлен в `.gitignore`, то он не перестанет отслеживаться. Если случайно добавить в `.gitignore` лишний файл, то это обнаружится только при перемещении файла в другое место. Если за раз перемещается много файлов, то потерю файла можно и не заметить.

Чтобы обнаружить проблемные файлы (которые одновременно и отслеживаются и игнорируются) нужно выполнить две команды:
```
# Remove the files from the index (not the actual files in the working copy)
$ git rm -r --cached .

# Add these removals to the Staging Area...
$ git add .
```
Источник: <https://www.git-tower.com/learn/git/faq/ignore-tracked-files-in-git>.

После этих двух команд проблемные файлы будут удалены, что легко будет увидеть в GitHub Desktop.

В репе Dviglo такими проблемными файлами оказались:
* bin/shell.html
* Source/ThirdParty/SDL/src/hidapi/configure.ac
