### PR TITLE
Удалил @property из комментов

### DIFF
--- a/source/dviglo/audio/audio.h
+++ b/source/dviglo/audio/audio.h
@@ -38,7 +38,6 @@ public:
     /// Suspend sound output.
     void Stop();
     /// Set master gain on a specific sound type such as sound effects, music or voice.
-    /// @property
     void SetMasterGain(const String& type, float gain);
     /// Pause playback of specific sound type. This allows to suspend e.g. sound effects or voice when the game is paused. By default all sound types are unpaused.
     void PauseSoundType(const String& type);
@@ -47,44 +46,35 @@ public:
     /// Resume playback of all sound types.
     void ResumeAll();
     /// Set active sound listener for 3D sounds.
-    /// @property
     void SetListener(SoundListener* listener);
     /// Stop any sound source playing a certain sound clip.
     void StopSound(Sound* sound);
 
     /// Return byte size of one sample.
-    /// @property
     u32 GetSampleSize() const { return sampleSize_; }
 
     /// Return mixing rate.
-    /// @property
     i32 GetMixRate() const { return mixRate_; }
 
     /// Return whether output is interpolated.
-    /// @property
     bool GetInterpolation() const { return interpolation_; }
 
     /// Return whether output is stereo.
-    /// @property
     bool IsStereo() const { return stereo_; }
 
     /// Return whether audio is being output.
-    /// @property
     bool IsPlaying() const { return playing_; }
 
     /// Return whether an audio stream has been reserved.
-    /// @property
     bool IsInitialized() const { return deviceID_ != 0; }
 
     /// Return master gain for a specific sound source type. Unknown sound types will return full gain (1).
-    /// @property
     float GetMasterGain(const String& type) const;
 
     /// Return whether specific sound type has been paused.
     bool IsSoundTypePaused(const String& type) const;
 
     /// Return active sound listener.
-    /// @property
     SoundListener* GetListener() const;
 
     /// Return all sound sources.

--- a/source/dviglo/audio/sound.h
+++ b/source/dviglo/audio/sound.h
@@ -42,7 +42,6 @@ public:
     /// Set uncompressed sound data format.
     void SetFormat(unsigned frequency, bool sixteenBit, bool stereo);
     /// Set loop on/off. If loop is enabled, sets the full sound as loop range.
-    /// @property
     void SetLooped(bool enable);
     /// Define loop.
     void SetLoop(unsigned repeatOffset, unsigned endOffset);
@@ -63,37 +62,30 @@ public:
     signed char* GetEnd() const { return end_; }
 
     /// Return length in seconds.
-    /// @property
     float GetLength() const;
 
     /// Return total sound data size.
     unsigned GetDataSize() const { return dataSize_; }
 
     /// Return sample size.
-    /// @property
     unsigned GetSampleSize() const;
 
     /// Return default frequency as a float.
-    /// @property
     float GetFrequency() const { return (float)frequency_; }
 
     /// Return default frequency as an integer.
     unsigned GetIntFrequency() const { return frequency_; }
 
     /// Return whether is looped.
-    /// @property
     bool IsLooped() const { return looped_; }
 
     /// Return whether data is sixteen bit.
-    /// @property
     bool IsSixteenBit() const { return sixteenBit_; }
 
     /// Return whether data is stereo.
-    /// @property
     bool IsStereo() const { return stereo_; }
 
     /// Return whether is compressed.
-    /// @property
     bool IsCompressed() const { return compressed_; }
 
     /// Fix interpolation by copying data from loop start to loop end (looped), or adding silence (oneshot). Called internally, does not normally need to be called, unless the sound data is modified manually on the fly.

--- a/source/dviglo/audio/sound_source.h
+++ b/source/dviglo/audio/sound_source.h
@@ -46,62 +46,48 @@ public:
     /// Stop playback.
     void Stop();
     /// Set sound type, determines the master gain group.
-    /// @property
     void SetSoundType(const String& type);
     /// Set frequency.
-    /// @property
     void SetFrequency(float frequency);
     /// Set gain. 0.0 is silence, 1.0 is full volume.
-    /// @property
     void SetGain(float gain);
     /// Set attenuation. 1.0 is unaltered. Used for distance attenuated playback.
     void SetAttenuation(float attenuation);
     /// Set stereo panning. -1.0 is full left and 1.0 is full right.
-    /// @property
     void SetPanning(float panning);
     /// Set to remove either the sound source component or its owner node from the scene automatically on sound playback completion. Disabled by default.
-    /// @property
     void SetAutoRemoveMode(AutoRemoveMode mode);
     /// Set new playback position.
     void SetPlayPosition(signed char* pos);
 
     /// Return sound.
-    /// @property
     Sound* GetSound() const { return sound_; }
 
     /// Return playback position.
     volatile signed char* GetPlayPosition() const { return position_; }
 
     /// Return sound type, determines the master gain group.
-    /// @property
     String GetSoundType() const { return soundType_; }
 
     /// Return playback time position.
-    /// @property
     float GetTimePosition() const { return timePosition_; }
 
     /// Return frequency.
-    /// @property
     float GetFrequency() const { return frequency_; }
 
     /// Return gain.
-    /// @property
     float GetGain() const { return gain_; }
 
     /// Return attenuation.
-    /// @property
     float GetAttenuation() const { return attenuation_; }
 
     /// Return stereo panning.
-    /// @property
     float GetPanning() const { return panning_; }
 
     /// Return automatic removal mode on sound playback completion.
-    /// @property
     AutoRemoveMode GetAutoRemoveMode() const { return autoRemove_; }
 
     /// Return whether is playing.
-    /// @property
     bool IsPlaying() const;
 
     /// Update the sound source. Perform subclass specific operations. Called by Audio.

--- a/source/dviglo/audio/sound_source_3d.h
+++ b/source/dviglo/audio/sound_source_3d.h
@@ -33,37 +33,28 @@ public:
     /// Set angle attenuation parameters.
     void SetAngleAttenuation(float innerAngle, float outerAngle);
     /// Set near distance. Inside this range sound will not be attenuated.
-    /// @property
     void SetNearDistance(float distance);
     /// Set far distance. Outside this range sound will be completely attenuated.
-    /// @property
     void SetFarDistance(float distance);
     /// Set inner angle in degrees. Inside this angle sound will not be attenuated.By default 360, meaning direction never has an effect.
-    /// @property
     void SetInnerAngle(float angle);
     /// Set outer angle in degrees. Outside this angle sound will be completely attenuated. By default 360, meaning direction never has an effect.
-    /// @property
     void SetOuterAngle(float angle);
     /// Set rolloff power factor, defines attenuation function shape.
-    /// @property
     void SetRolloffFactor(float factor);
     /// Calculate attenuation and panning based on current position and listener position.
     void CalculateAttenuation();
 
     /// Return near distance.
-    /// @property
     float GetNearDistance() const { return nearDistance_; }
 
     /// Return far distance.
-    /// @property
     float GetFarDistance() const { return farDistance_; }
 
     /// Return inner angle in degrees.
-    /// @property
     float GetInnerAngle() const { return innerAngle_; }
 
     /// Return outer angle in degrees.
-    /// @property
     float GetOuterAngle() const { return outerAngle_; }
 
     /// Return rolloff power factor.

--- a/source/dviglo/audio/sound_source_3d.h
+++ b/source/dviglo/audio/sound_source_3d.h
@@ -58,7 +58,6 @@ public:
     float GetOuterAngle() const { return outerAngle_; }
 
     /// Return rolloff power factor.
-    /// @property{get_rolloffFactor}
     float RollAngleoffFactor() const { return rolloffFactor_; }
 
 protected:

--- a/source/dviglo/container/ref_counted.h
+++ b/source/dviglo/container/ref_counted.h
@@ -58,10 +58,8 @@ public:
     /// @manualbind
     void ReleaseRef();
     /// Return reference count.
-    /// @property
     int Refs() const;
     /// Return weak reference count.
-    /// @property
     int WeakRefs() const;
 
     /// Return pointer to the reference count structure.

--- a/source/dviglo/container/str.h
+++ b/source/dviglo/container/str.h
@@ -436,7 +436,6 @@ public:
     /// Construct UTF8 content from wide characters.
     void SetUTF8FromWChar(const wchar_t* str);
     /// Calculate number of characters in UTF8 content.
-    /// @property{get_utf8Length}
     i32 LengthUTF8() const;
     /// Return byte offset to char in UTF8 content.
     i32 ByteOffsetUTF8(i32 index) const;

--- a/source/dviglo/container/str.h
+++ b/source/dviglo/container/str.h
@@ -412,14 +412,12 @@ public:
     const char* CString() const { return GetBuffer(); }
 
     /// Return length.
-    /// @property
     i32 Length() const { return IsShort() ? GetShortStringLength() : data_.longString_.length_; }
 
     /// Return buffer capacity.
     i32 Capacity() const { return IsShort() ? SHORT_STRING_CAPACITY : data_.longString_.capacity_; }
 
     /// Return whether the string is empty.
-    /// @property
     bool Empty() const { return Length() == 0; }
 
     /// Return comparison result with a string.

--- a/source/dviglo/core/object.h
+++ b/source/dviglo/core/object.h
@@ -73,10 +73,8 @@ public:
     ~Object() override;
 
     /// Return type hash.
-    /// @property
     virtual StringHash GetType() const = 0;
     /// Return type name.
-    /// @property
     virtual const String& GetTypeName() const = 0;
     /// Return type info.
     virtual const TypeInfo* GetTypeInfo() const = 0;
@@ -129,13 +127,10 @@ public:
     /// Return execution context.
     Context* GetContext() const { return context_; }
     /// Return global variable based on key.
-    /// @property
     const Variant& GetGlobalVar(StringHash key) const;
     /// Return all global variables.
-    /// @property
     const VariantMap& GetGlobalVars() const;
     /// Set global variable with the respective key and value.
-    /// @property
     void SetGlobalVar(StringHash key, const Variant& value);
     /// Return subsystem by type.
     Object* GetSubsystem(StringHash type) const;
@@ -154,7 +149,6 @@ public:
     /// Template version of returning a subsystem.
     template <class T> T* GetSubsystem() const;
     /// Return object category. Categories are (optionally) registered along with the object factory. Return an empty string if the object category is not registered.
-    /// @property
     const String& GetCategory() const;
 
     /// Block object from sending and receiving events.

--- a/source/dviglo/core/spline.h
+++ b/source/dviglo/core/spline.h
@@ -56,21 +56,18 @@ public:
     }
 
     /// Return the interpolation mode.
-    /// @property
     InterpolationMode GetInterpolationMode() const { return interpolationMode_; }
 
     /// Return the knots of the spline.
     const VariantVector& GetKnots() const { return knots_; }
 
     /// Return the knot at the specific index.
-    /// @property
     Variant GetKnot(unsigned index) const { return knots_[index]; }
 
     /// Return the T of the point of the spline at f from 0.f - 1.f.
     Variant GetPoint(float f) const;
 
     /// Set the interpolation mode.
-    /// @property
     void SetInterpolationMode(InterpolationMode interpolationMode) { interpolationMode_ = interpolationMode; }
 
     /// Set the knots of the spline.

--- a/source/dviglo/core/timer.h
+++ b/source/dviglo/core/timer.h
@@ -75,22 +75,18 @@ public:
     void SetTimerPeriod(unsigned mSec);
 
     /// Return frame number, starting from 1 once BeginFrame() is called for the first time.
-    /// @property
     i32 GetFrameNumber() const { return frameNumber_; }
 
     /// Return current frame timestep as seconds.
-    /// @property
     float GetTimeStep() const { return timeStep_; }
 
     /// Return current low-resolution timer period in milliseconds.
     unsigned GetTimerPeriod() const { return timerPeriod_; }
 
     /// Return elapsed time from program start as seconds.
-    /// @property
     float GetElapsedTime();
 
     /// Return current frames per second.
-    /// @property
     float GetFramesPerSecond() const;
 
     /// Get system time as milliseconds.

--- a/source/dviglo/core/variant.h
+++ b/source/dviglo/core/variant.h
@@ -1353,20 +1353,16 @@ public:
     }
 
     /// Return value's type.
-    /// @property
     VariantType GetType() const { return type_; }
 
     /// Return value's type name.
-    /// @property
     String GetTypeName() const;
     /// Convert value to string. Pointers are returned as null, and VariantBuffer or VariantMap are not supported and return empty.
     String ToString() const;
     /// Return true when the variant value is considered zero according to its actual type.
-    /// @property
     bool IsZero() const;
 
     /// Return true when the variant is empty (i.e. not initialized yet).
-    /// @property
     bool IsEmpty() const { return type_ == VAR_NONE; }
 
     /// Return true when the variant stores custom type.

--- a/source/dviglo/engine/console.h
+++ b/source/dviglo/engine/console.h
@@ -32,33 +32,25 @@ public:
     ~Console() override;
 
     /// Set UI elements' style from an XML file.
-    /// @property
     void SetDefaultStyle(XMLFile* style);
     /// Show or hide.
-    /// @property
     void SetVisible(bool enable);
     /// Toggle visibility.
     void Toggle();
 
     /// Automatically set console to visible when receiving an error log message.
-    /// @property
     void SetAutoVisibleOnError(bool enable) { autoVisibleOnError_ = enable; }
 
     /// Set the command interpreter.
-    /// @property
     void SetCommandInterpreter(const String& interpreter) { commandInterpreter_ = interpreter; }
 
     /// Set number of buffered rows.
-    /// @property
     void SetNumBufferedRows(i32 rows);
     /// Set number of displayed rows.
-    /// @property
     void SetNumRows(i32 rows);
     /// Set command history maximum size, 0 disables history.
-    /// @property
     void SetNumHistoryRows(i32 rows);
     /// Set whether to automatically focus the line edit when showing. Default true on desktops and false on mobile devices, as on mobiles it would pop up the screen keyboard.
-    /// @property
     void SetFocusOnShow(bool enable);
     /// Add auto complete option.
     void AddAutoComplete(const String& option);
@@ -68,58 +60,45 @@ public:
     void UpdateElements();
 
     /// Return the UI style file.
-    /// @property
     XMLFile* GetDefaultStyle() const;
 
     /// Return the background element.
-    /// @property
     BorderImage* GetBackground() const { return background_; }
 
     /// Return the line edit element.
-    /// @property
     LineEdit* GetLineEdit() const { return lineEdit_; }
 
     /// Return the close butoon element.
-    /// @property
     Button* GetCloseButton() const { return closeButton_; }
 
     /// Return whether is visible.
-    /// @property
     bool IsVisible() const;
 
     /// Return true when console is set to automatically visible when receiving an error log message.
-    /// @property
     bool IsAutoVisibleOnError() const { return autoVisibleOnError_; }
 
     /// Return the last used command interpreter.
-    /// @property
     const String& GetCommandInterpreter() const { return commandInterpreter_; }
 
     /// Return number of buffered rows.
-    /// @property
     i32 GetNumBufferedRows() const;
 
     /// Return number of displayed rows.
-    /// @property
     i32 GetNumRows() const { return displayedRows_; }
 
     /// Copy selected rows to system clipboard.
     void CopySelectedRows() const;
 
     /// Return history maximum size.
-    /// @property
     i32 GetNumHistoryRows() const { return historyRows_; }
 
     /// Return current history position.
-    /// @property
     i32 GetHistoryPosition() const { return historyPosition_; }
 
     /// Return history row at index.
-    /// @property
     const String& GetHistoryRow(i32 index) const;
 
     /// Return whether automatically focuses the line edit when showing.
-    /// @property
     bool GetFocusOnShow() const { return focusOnShow_; }
 
 private:

--- a/source/dviglo/engine/debug_hud.h
+++ b/source/dviglo/engine/debug_hud.h
@@ -41,21 +41,16 @@ public:
     /// Update. Called by HandlePostUpdate().
     void Update();
     /// Set UI elements' style from an XML file.
-    /// @property
     void SetDefaultStyle(XMLFile* style);
 
     /// Set elements to show.
-    /// @property
     void SetMode(DebugHudElements mode);
 
     /// Set maximum profiler block depth, default unlimited.
-    /// @property
     void SetProfilerMaxDepth(unsigned depth);
     /// Set profiler accumulation interval in seconds.
-    /// @property
     void SetProfilerInterval(float interval);
     /// Set whether to show 3D geometry primitive/batch count only. Default false.
-    /// @property
     void SetUseRendererStats(bool enable);
 
     /// Toggle elements.
@@ -65,39 +60,30 @@ public:
     void ToggleAll();
 
     /// Return the UI style file.
-    /// @property
     XMLFile* GetDefaultStyle() const;
 
     /// Return rendering stats text.
-    /// @property
     Text* GetStatsText() const { return statsText_; }
 
     /// Return rendering mode text.
-    /// @property
     Text* GetModeText() const { return modeText_; }
 
     /// Return profiler text.
-    /// @property
     Text* GetProfilerText() const { return profilerText_; }
 
     /// Return memory text.
-    /// @property
     Text* GetMemoryText() const { return memoryText_; }
 
     /// Return currently shown elements.
-    /// @property
     DebugHudElements GetMode() const { return mode_; }
 
     /// Return maximum profiler block depth.
-    /// @property
     unsigned GetProfilerMaxDepth() const { return profilerMaxDepth_; }
 
     /// Return profiler accumulation interval in seconds.
-    /// @property
     float GetProfilerInterval() const;
 
     /// Return whether showing 3D geometry primitive/batch count only.
-    /// @property
     bool GetUseRendererStats() const { return useRendererStats_; }
 
     /// Set application-specific stats.

--- a/source/dviglo/engine/engine.h
+++ b/source/dviglo/engine/engine.h
@@ -35,22 +35,16 @@ public:
     /// Create the debug hud.
     DebugHud* CreateDebugHud();
     /// Set minimum frames per second. If FPS goes lower than this, time will appear to slow down.
-    /// @property
     void SetMinFps(int fps);
     /// Set maximum frames per second. The engine will sleep if FPS is higher than this.
-    /// @property
     void SetMaxFps(int fps);
     /// Set maximum frames per second when the application does not have input focus.
-    /// @property
     void SetMaxInactiveFps(int fps);
     /// Set how many frames to average for timestep smoothing. Default is 2. 1 disables smoothing.
-    /// @property
     void SetTimeStepSmoothing(int frames);
     /// Set whether to pause update events and audio when minimized.
-    /// @property
     void SetPauseMinimized(bool enable);
     /// Set whether to exit automatically on exit request (window close button).
-    /// @property
     void SetAutoExit(bool enable);
     /// Override timestep of the next frame. Should be called in between RunFrame() calls.
     void SetNextTimeStep(float seconds);
@@ -67,39 +61,30 @@ public:
     float GetNextTimeStep() const { return timeStep_; }
 
     /// Return the minimum frames per second.
-    /// @property
     int GetMinFps() const { return minFps_; }
 
     /// Return the maximum frames per second.
-    /// @property
     int GetMaxFps() const { return maxFps_; }
 
     /// Return the maximum frames per second when the application does not have input focus.
-    /// @property
     int GetMaxInactiveFps() const { return maxInactiveFps_; }
 
     /// Return how many frames to average for timestep smoothing.
-    /// @property
     int GetTimeStepSmoothing() const { return timeStepSmoothing_; }
 
     /// Return whether to pause update events and audio when minimized.
-    /// @property
     bool GetPauseMinimized() const { return pauseMinimized_; }
 
     /// Return whether to exit automatically on exit request.
-    /// @property
     bool GetAutoExit() const { return autoExit_; }
 
     /// Return whether engine has been initialized.
-    /// @property
     bool IsInitialized() const { return initialized_; }
 
     /// Return whether exit has been requested.
-    /// @property
     bool IsExiting() const { return exiting_; }
 
     /// Return whether the engine has been created in headless mode.
-    /// @property
     bool IsHeadless() const { return headless_; }
 
     /// Send frame update events.

--- a/source/dviglo/graphics/animated_model.h
+++ b/source/dviglo/graphics/animated_model.h
@@ -68,10 +68,8 @@ public:
     /// Remove all animations.
     void RemoveAllAnimationStates();
     /// Set animation LOD bias.
-    /// @property
     void SetAnimationLodBias(float bias);
     /// Set whether to update animation and the bounding box when not visible. Recommended to enable for physically controlled models like ragdolls.
-    /// @property
     void SetUpdateInvisible(bool enable);
     /// Set vertex morph weight by index.
     void SetMorphWeight(i32 index, float weight);
@@ -86,14 +84,12 @@ public:
     void ApplyAnimation();
 
     /// Return skeleton.
-    /// @property
     Skeleton& GetSkeleton() { return skeleton_; }
 
     /// Return all animation states.
     const Vector<SharedPtr<AnimationState>>& GetAnimationStates() const { return animationStates_; }
 
     /// Return number of animation states.
-    /// @property
     i32 GetNumAnimationStates() const { return animationStates_.Size(); }
 
     /// Return animation state by animation pointer.
@@ -107,11 +103,9 @@ public:
     AnimationState* GetAnimationState(i32 index) const;
 
     /// Return animation LOD bias.
-    /// @property
     float GetAnimationLodBias() const { return animationLodBias_; }
 
     /// Return whether to update animation when not visible.
-    /// @property
     bool GetUpdateInvisible() const { return updateInvisible_; }
 
     /// Return all vertex morphs.
@@ -121,7 +115,6 @@ public:
     const Vector<SharedPtr<VertexBuffer>>& GetMorphVertexBuffers() const { return morphVertexBuffers_; }
 
     /// Return number of vertex morphs.
-    /// @property
     i32 GetNumMorphs() const { return morphs_.Size(); }
 
     /// Return vertex morph weight by index.

--- a/source/dviglo/graphics/animated_model.h
+++ b/source/dviglo/graphics/animated_model.h
@@ -74,7 +74,6 @@ public:
     /// Set vertex morph weight by index.
     void SetMorphWeight(i32 index, float weight);
     /// Set vertex morph weight by name.
-    /// @property{set_morphWeights}
     void SetMorphWeight(const String& name, float weight);
     /// Set vertex morph weight by name hash.
     void SetMorphWeight(StringHash nameHash, float weight);
@@ -95,7 +94,6 @@ public:
     /// Return animation state by animation pointer.
     AnimationState* GetAnimationState(Animation* animation) const;
     /// Return animation state by animation name.
-    /// @property{get_animationStates}
     AnimationState* GetAnimationState(const String& animationName) const;
     /// Return animation state by animation name hash.
     AnimationState* GetAnimationState(StringHash animationNameHash) const;
@@ -120,7 +118,6 @@ public:
     /// Return vertex morph weight by index.
     float GetMorphWeight(i32 index) const;
     /// Return vertex morph weight by name.
-    /// @property{get_morphWeights}
     float GetMorphWeight(const String& name) const;
     /// Return vertex morph weight by name hash.
     float GetMorphWeight(StringHash nameHash) const;

--- a/source/dviglo/graphics/animation.h
+++ b/source/dviglo/graphics/animation.h
@@ -54,7 +54,6 @@ struct URHO3D_API AnimationTrack
     }
 
     /// Assign keyframe at index.
-    /// @property{set_keyFrames}
     void SetKeyFrame(i32 index, const AnimationKeyFrame& keyFrame);
     /// Add a keyframe at the end.
     void AddKeyFrame(const AnimationKeyFrame& keyFrame);
@@ -127,7 +126,6 @@ public:
     /// Remove all tracks. This is unsafe if the animation is currently used in playback.
     void RemoveAllTracks();
     /// Set a trigger point at index.
-    /// @property{set_triggers}
     void SetTrigger(i32 index, const AnimationTriggerPoint& trigger);
     /// Add a trigger point.
     void AddTrigger(const AnimationTriggerPoint& trigger);
@@ -161,7 +159,6 @@ public:
     AnimationTrack *GetTrack(i32 index);
 
     /// Return animation track by name.
-    /// @property{get_tracks}
     AnimationTrack* GetTrack(const String& name);
     /// Return animation track by name hash.
     AnimationTrack* GetTrack(StringHash nameHash);

--- a/source/dviglo/graphics/animation.h
+++ b/source/dviglo/graphics/animation.h
@@ -68,7 +68,6 @@ struct URHO3D_API AnimationTrack
     /// Return keyframe at index, or null if not found.
     AnimationKeyFrame* GetKeyFrame(i32 index);
     /// Return number of keyframes.
-    /// @property
     i32 GetNumKeyFrames() const { return keyFrames_.Size(); }
     /// Return keyframe index based on time and previous index. Return false if animation is empty.
     bool GetKeyFrameIndex(float time, i32& index) const;
@@ -118,10 +117,8 @@ public:
     bool Save(Serializer& dest) const override;
 
     /// Set animation name.
-    /// @property
     void SetAnimationName(const String& name);
     /// Set animation length.
-    /// @property
     void SetLength(float length);
     /// Create and return a track by name. If track by same name already exists, returns the existing.
     AnimationTrack* CreateTrack(const String& name);
@@ -141,27 +138,23 @@ public:
     /// Remove all trigger points.
     void RemoveAllTriggers();
     /// Resize trigger point vector.
-    /// @property
     void SetNumTriggers(i32 num);
     /// Clone the animation.
     SharedPtr<Animation> Clone(const String& cloneName = String::EMPTY) const;
 
     /// Return animation name.
-    /// @property
     const String& GetAnimationName() const { return animationName_; }
 
     /// Return animation name hash.
     StringHash GetAnimationNameHash() const { return animationNameHash_; }
 
     /// Return animation length.
-    /// @property
     float GetLength() const { return length_; }
 
     /// Return all animation tracks.
     const HashMap<StringHash, AnimationTrack>& GetTracks() const { return tracks_; }
 
     /// Return number of animation tracks.
-    /// @property
     i32 GetNumTracks() const { return tracks_.Size(); }
 
     /// Return animation track by index.
@@ -177,7 +170,6 @@ public:
     const Vector<AnimationTriggerPoint>& GetTriggers() const { return triggers_; }
 
     /// Return number of animation trigger points.
-    /// @property
     i32 GetNumTriggers() const { return triggers_.Size(); }
 
     /// Return a trigger point by index.

--- a/source/dviglo/graphics/animation_state.h
+++ b/source/dviglo/graphics/animation_state.h
@@ -97,7 +97,6 @@ public:
     /// Return per-bone blending weight by track index.
     float GetBoneWeight(i32 index) const;
     /// Return per-bone blending weight by name.
-    /// @property{get_boneWeights}
     float GetBoneWeight(const String& name) const;
     /// Return per-bone blending weight by name.
     float GetBoneWeight(StringHash nameHash) const;

--- a/source/dviglo/graphics/animation_state.h
+++ b/source/dviglo/graphics/animation_state.h
@@ -63,19 +63,14 @@ public:
     ~AnimationState() override;
 
     /// Set start bone. Not supported in node animation mode. Resets any assigned per-bone weights.
-    /// @property
     void SetStartBone(Bone* startBone);
     /// Set looping enabled/disabled.
-    /// @property
     void SetLooped(bool looped);
     /// Set blending weight.
-    /// @property
     void SetWeight(float weight);
     /// Set blending mode.
-    /// @property
     void SetBlendMode(AnimationBlendMode mode);
     /// Set time position. Does not fire animation triggers.
-    /// @property
     void SetTime(float time);
     /// Set per-bone blending weight by track index. Default is 1.0 (full), is multiplied  with the state's blending weight when applying the animation. Optionally recurses to child bones.
     void SetBoneWeight(i32 index, float weight, bool recursive = false);
@@ -88,21 +83,16 @@ public:
     /// Modify time position. %Animation triggers will be fired.
     void AddTime(float delta);
     /// Set blending layer.
-    /// @property
     void SetLayer(unsigned char layer); // TODO: i8?
 
     /// Return animation.
-    /// @property
     Animation* GetAnimation() const { return animation_; }
 
     /// Return animated model this state belongs to (model mode).
-    /// @property
     AnimatedModel* GetModel() const;
     /// Return root scene node this state controls (node hierarchy mode).
-    /// @property
     Node* GetNode() const;
     /// Return start bone.
-    /// @property
     Bone* GetStartBone() const;
     /// Return per-bone blending weight by track index.
     float GetBoneWeight(i32 index) const;
@@ -119,31 +109,24 @@ public:
     i32 GetTrackIndex(StringHash nameHash) const;
 
     /// Return whether weight is nonzero.
-    /// @property
     bool IsEnabled() const { return weight_ > 0.0f; }
 
     /// Return whether looped.
-    /// @property
     bool IsLooped() const { return looped_; }
 
     /// Return blending weight.
-    /// @property
     float GetWeight() const { return weight_; }
 
     /// Return blending mode.
-    /// @property
     AnimationBlendMode GetBlendMode() const { return blendingMode_; }
 
     /// Return time position.
-    /// @property
     float GetTime() const { return time_; }
 
     /// Return animation length.
-    /// @property
     float GetLength() const;
 
     /// Return blending layer.
-    /// @property
     unsigned char GetLayer() const { return layer_; }
 
     /// Apply the animation at the current time position.

--- a/source/dviglo/graphics/billboard_set.h
+++ b/source/dviglo/graphics/billboard_set.h
@@ -64,41 +64,30 @@ public:
     UpdateGeometryType GetUpdateGeometryType() override;
 
     /// Set material.
-    /// @property
     void SetMaterial(Material* material);
     /// Set number of billboards.
-    /// @property
     void SetNumBillboards(i32 num);
     /// Set whether billboards are relative to the scene node. Default true.
-    /// @property
     void SetRelative(bool enable);
     /// Set whether scene node scale affects billboards' size. Default true.
-    /// @property
     void SetScaled(bool enable);
     /// Set whether billboards are sorted by distance. Default false.
-    /// @property
     void SetSorted(bool enable);
     /// Set whether billboards have fixed size on screen (measured in pixels) regardless of distance to camera. Default false.
-    /// @property
     void SetFixedScreenSize(bool enable);
     /// Set how the billboards should rotate in relation to the camera. Default is to follow camera rotation on all axes (FC_ROTATE_XYZ).
-    /// @property
     void SetFaceCameraMode(FaceCameraMode mode);
     /// Set minimal angle between billboard normal and look-at direction.
-    /// @property
     void SetMinAngle(float angle);
     /// Set animation LOD bias.
-    /// @property
     void SetAnimationLodBias(float bias);
     /// Mark for bounding box and vertex buffer update. Call after modifying the billboards.
     void Commit();
 
     /// Return material.
-    /// @property
     Material* GetMaterial() const;
 
     /// Return number of billboards.
-    /// @property
     i32 GetNumBillboards() const { return billboards_.Size(); }
 
     /// Return all billboards.
@@ -109,31 +98,24 @@ public:
     Billboard* GetBillboard(i32 index);
 
     /// Return whether billboards are relative to the scene node.
-    /// @property
     bool IsRelative() const { return relative_; }
 
     /// Return whether scene node scale affects billboards' size.
-    /// @property
     bool IsScaled() const { return scaled_; }
 
     /// Return whether billboards are sorted.
-    /// @property
     bool IsSorted() const { return sorted_; }
 
     /// Return whether billboards are fixed screen size.
-    /// @property
     bool IsFixedScreenSize() const { return fixedScreenSize_; }
 
     /// Return how the billboards rotate in relation to the camera.
-    /// @property
     FaceCameraMode GetFaceCameraMode() const { return faceCameraMode_; }
 
     /// Return minimal angle between billboard normal and look-at direction.
-    /// @property
     float GetMinAngle() const { return minAngle_; }
 
     /// Return animation LOD bias.
-    /// @property
     float GetAnimationLodBias() const { return animationLodBias_; }
 
     /// Set material attribute.

--- a/source/dviglo/graphics/billboard_set.h
+++ b/source/dviglo/graphics/billboard_set.h
@@ -94,7 +94,6 @@ public:
     Vector<Billboard>& GetBillboards() { return billboards_; }
 
     /// Return billboard by index.
-    /// @property{get_billboards}
     Billboard* GetBillboard(i32 index);
 
     /// Return whether billboards are relative to the scene node.

--- a/source/dviglo/graphics/camera.h
+++ b/source/dviglo/graphics/camera.h
@@ -46,136 +46,100 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set near clip distance.
-    /// @property
     void SetNearClip(float nearClip);
     /// Set far clip distance.
-    /// @property
     void SetFarClip(float farClip);
     /// Set vertical field of view in degrees.
-    /// @property
     void SetFov(float fov);
     /// Set orthographic mode view uniform size.
-    /// @property
     void SetOrthoSize(float orthoSize);
     /// Set orthographic mode view non-uniform size. Disables the auto aspect ratio -mode.
     void SetOrthoSize(const Vector2& orthoSize);
     /// Set aspect ratio manually. Disables the auto aspect ratio -mode.
-    /// @property
     void SetAspectRatio(float aspectRatio);
     /// Set polygon fill mode to use when rendering a scene.
-    /// @property
     void SetFillMode(FillMode mode);
     /// Set zoom.
-    /// @property
     void SetZoom(float zoom);
     /// Set LOD bias.
-    /// @property
     void SetLodBias(float bias);
     /// Set view mask. Will be and'ed with object's view mask to see if the object should be rendered.
-    /// @property
     void SetViewMask(unsigned mask);
     /// Set view override flags.
-    /// @property
     void SetViewOverrideFlags(ViewOverrideFlags flags);
     /// Set orthographic mode enabled/disabled.
-    /// @property
     void SetOrthographic(bool enable);
     /// Set automatic aspect ratio based on viewport dimensions. Enabled by default.
-    /// @property
     void SetAutoAspectRatio(bool enable);
     /// Set projection offset. It needs to be calculated as (offset in pixels) / (viewport dimensions).
-    /// @property
     void SetProjectionOffset(const Vector2& offset);
     /// Set reflection mode.
-    /// @property
     void SetUseReflection(bool enable);
     /// Set reflection plane in world space for reflection mode.
-    /// @property
     void SetReflectionPlane(const Plane& plane);
     /// Set whether to use a custom clip plane.
-    /// @property
     void SetUseClipping(bool enable);
     /// Set custom clipping plane in world space.
-    /// @property
     void SetClipPlane(const Plane& plane);
     /// Set vertical flipping mode. Called internally by View to resolve OpenGL / Direct3D9 rendertarget sampling differences.
     void SetFlipVertical(bool enable);
     /// Set custom projection matrix, which should be specified in D3D convention with depth range 0 - 1. Disables auto aspect ratio.
-    /// @property
     /** Change any of the standard view parameters (FOV, far clip, zoom, etc.) to revert to the standard projection.
         Note that the custom projection is not serialized or replicated through the network.
      */
     void SetProjection(const Matrix4& projection);
 
     /// Return far clip distance. If a custom projection matrix is in use, is calculated from it instead of the value assigned with SetFarClip().
-    /// @property
     float GetFarClip() const;
 
     /// Return near clip distance. If a custom projection matrix is in use, is calculated from it instead of the value assigned with SetNearClip().
-    /// @property
     float GetNearClip() const;
 
     /// Return vertical field of view in degrees.
-    /// @property
     float GetFov() const { return fov_; }
 
     /// Return orthographic mode size.
-    /// @property
     float GetOrthoSize() const { return orthoSize_; }
 
     /// Return aspect ratio.
-    /// @property
     float GetAspectRatio() const { return aspectRatio_; }
 
     /// Return zoom.
-    /// @property
     float GetZoom() const { return zoom_; }
 
     /// Return LOD bias.
-    /// @property
     float GetLodBias() const { return lodBias_; }
 
     /// Return view mask.
-    /// @property
     unsigned GetViewMask() const { return viewMask_; }
 
     /// Return view override flags.
-    /// @property
     ViewOverrideFlags GetViewOverrideFlags() const { return viewOverrideFlags_; }
 
     /// Return fill mode.
-    /// @property
     FillMode GetFillMode() const { return fillMode_; }
 
     /// Return orthographic flag.
-    /// @property
     bool IsOrthographic() const { return orthographic_; }
 
     /// Return auto aspect ratio flag.
-    /// @property
     bool GetAutoAspectRatio() const { return autoAspectRatio_; }
 
     /// Return frustum in world space.
-    /// @property
     const Frustum& GetFrustum() const;
     /// Return projection matrix. It's in D3D convention with depth range 0 - 1.
-    /// @property
     Matrix4 GetProjection() const;
     /// Return projection matrix converted to API-specific format for use as a shader parameter.
-    /// @property
     Matrix4 GetGPUProjection() const;
     /// Return view matrix.
-    /// @property
     const Matrix3x4& GetView() const;
     /// Return frustum near and far sizes.
     void GetFrustumSize(Vector3& near, Vector3& far) const;
     /// Return half view size.
-    /// @property
     float GetHalfViewSize() const;
     /// Return frustum split by custom near and far clip distances.
     Frustum GetSplitFrustum(float nearClip, float farClip) const;
     /// Return frustum in view space.
-    /// @property
     Frustum GetViewSpaceFrustum() const;
     /// Return split frustum in view space.
     Frustum GetViewSpaceSplitFrustum(float nearClip, float farClip) const;
@@ -189,23 +153,18 @@ public:
     Vector3 ScreenToWorldPoint(const Vector3& screenPos) const;
 
     /// Return projection offset.
-    /// @property
     const Vector2& GetProjectionOffset() const { return projectionOffset_; }
 
     /// Return whether is using reflection.
-    /// @property
     bool GetUseReflection() const { return useReflection_; }
 
     /// Return the reflection plane.
-    /// @property
     const Plane& GetReflectionPlane() const { return reflectionPlane_; }
 
     /// Return whether is using a custom clipping plane.
-    /// @property
     bool GetUseClipping() const { return useClipping_; }
 
     /// Return the custom clipping plane.
-    /// @property
     const Plane& GetClipPlane() const { return clipPlane_; }
 
     /// Return vertical flipping mode.
@@ -223,7 +182,6 @@ public:
     /// Return a world rotation for facing a camera on certain axes based on the existing world rotation.
     Quaternion GetFaceCameraRotation(const Vector3& position, const Quaternion& rotation, FaceCameraMode mode, float minAngle = 0.0f);
     /// Get effective world transform for matrix and frustum calculations including reflection but excluding node scaling.
-    /// @property
     Matrix3x4 GetEffectiveWorldTransform() const;
     /// Return if projection parameters are valid for rendering and raycasting.
     bool IsProjectionValid() const;

--- a/source/dviglo/graphics/custom_geometry.h
+++ b/source/dviglo/graphics/custom_geometry.h
@@ -77,7 +77,6 @@ public:
     /// Set material on all geometries.
     void SetMaterial(Material* material);
     /// Set material on one geometry. Return true if successful.
-    /// @property{set_materials}
     bool SetMaterial(unsigned index, Material* material);
 
     /// Return number of geometries.
@@ -90,7 +89,6 @@ public:
     bool IsDynamic() const { return dynamic_; }
 
     /// Return material by geometry index.
-    /// @property{get_materials}
     Material* GetMaterial(unsigned index = 0) const;
 
     /// Return all vertices. These can be edited; calling Commit() updates the vertex buffer.

--- a/source/dviglo/graphics/custom_geometry.h
+++ b/source/dviglo/graphics/custom_geometry.h
@@ -53,10 +53,8 @@ public:
     /// Clear all geometries.
     void Clear();
     /// Set number of geometries.
-    /// @property
     void SetNumGeometries(unsigned num);
     /// Set vertex buffer dynamic mode. A dynamic buffer should be faster to update frequently. Effective at the next Commit() call.
-    /// @property
     void SetDynamic(bool enable);
     /// Begin defining a geometry. Clears existing vertices in that index.
     void BeginGeometry(unsigned index, PrimitiveType type);
@@ -77,22 +75,18 @@ public:
     /// Update vertex buffer and calculate the bounding box. Call after finishing defining geometry.
     void Commit();
     /// Set material on all geometries.
-    /// @property
     void SetMaterial(Material* material);
     /// Set material on one geometry. Return true if successful.
     /// @property{set_materials}
     bool SetMaterial(unsigned index, Material* material);
 
     /// Return number of geometries.
-    /// @property
     unsigned GetNumGeometries() const { return geometries_.Size(); }
 
     /// Return number of vertices in a geometry.
-    /// @property
     unsigned GetNumVertices(unsigned index) const;
 
     /// Return whether vertex buffer dynamic mode is enabled.
-    /// @property
     bool IsDynamic() const { return dynamic_; }
 
     /// Return material by geometry index.

--- a/source/dviglo/graphics/debug_renderer.h
+++ b/source/dviglo/graphics/debug_renderer.h
@@ -84,7 +84,6 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set line antialiasing on/off. Default false.
-    /// @property
     void SetLineAntiAlias(bool enable);
     /// Set the camera viewpoint. Call before rendering, or before adding geometry if you want to use culling.
     void SetView(Camera* camera);
@@ -136,7 +135,6 @@ public:
     void Render();
 
     /// Return whether line antialiasing is enabled.
-    /// @property
     bool GetLineAntiAlias() const { return lineAntiAlias_; }
 
     /// Return the view transform.

--- a/source/dviglo/graphics/decal_set.h
+++ b/source/dviglo/graphics/decal_set.h
@@ -109,16 +109,12 @@ public:
     UpdateGeometryType GetUpdateGeometryType() override;
 
     /// Set material. The material should use a small negative depth bias to avoid Z-fighting.
-    /// @property
     void SetMaterial(Material* material);
     /// Set maximum number of decal vertices.
-    /// @property
     void SetMaxVertices(unsigned num);
     /// Set maximum number of decal vertex indices.
-    /// @property
     void SetMaxIndices(unsigned num);
     /// Set whether to optimize GPU buffer sizes according to current amount of decals. Default false, which will size the buffers according to the maximum vertices/indices. When true, buffers will be reallocated whenever decals are added/removed, which can be worse for performance.
-    /// @property
     void SetOptimizeBufferSize(bool enable);
     /// Add a decal at world coordinates, using a target drawable's geometry for reference. If the decal needs to move with the target, the decal component should be created to the target's node. Return true if successful.
     bool AddDecal(Drawable* target, const Vector3& worldPosition, const Quaternion& worldRotation, float size, float aspectRatio,
@@ -130,31 +126,24 @@ public:
     void RemoveAllDecals();
 
     /// Return material.
-    /// @property
     Material* GetMaterial() const;
 
     /// Return number of decals.
-    /// @property
     unsigned GetNumDecals() const { return decals_.Size(); }
 
     /// Retur number of vertices in the decals.
-    /// @property
     unsigned GetNumVertices() const { return numVertices_; }
 
     /// Retur number of vertex indices in the decals.
-    /// @property
     unsigned GetNumIndices() const { return numIndices_; }
 
     /// Return maximum number of decal vertices.
-    /// @property
     unsigned GetMaxVertices() const { return maxVertices_; }
 
     /// Return maximum number of decal vertex indices.
-    /// @property
     unsigned GetMaxIndices() const { return maxIndices_; }
 
     /// Return whether is optimizing GPU buffer sizes according to current amount of decals.
-    /// @property
     bool GetOptimizeBufferSize() const { return optimizeBufferSize_; }
 
     /// Set material attribute.

--- a/source/dviglo/graphics/drawable.h
+++ b/source/dviglo/graphics/drawable.h
@@ -137,98 +137,73 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set draw distance.
-    /// @property
     void SetDrawDistance(float distance);
     /// Set shadow draw distance.
-    /// @property
     void SetShadowDistance(float distance);
     /// Set LOD bias.
-    /// @property
     void SetLodBias(float bias);
     /// Set view mask. Is and'ed with camera's view mask to see if the object should be rendered.
-    /// @property
     void SetViewMask(mask32 mask);
     /// Set light mask. Is and'ed with light's and zone's light mask to see if the object should be lit.
-    /// @property
     void SetLightMask(mask32 mask);
     /// Set shadow mask. Is and'ed with light's light mask and zone's shadow mask to see if the object should be rendered to a shadow map.
-    /// @property
     void SetShadowMask(mask32 mask);
     /// Set zone mask. Is and'ed with zone's zone mask to see if the object should belong to the zone.
-    /// @property
     void SetZoneMask(mask32 mask);
     /// Set maximum number of per-pixel lights. Default 0 is unlimited.
-    /// @property
     void SetMaxLights(i32 num);
     /// Set shadowcaster flag.
-    /// @property
     void SetCastShadows(bool enable);
     /// Set occlusion flag.
-    /// @property
     void SetOccluder(bool enable);
     /// Set occludee flag.
-    /// @property
     void SetOccludee(bool enable);
     /// Mark for update and octree reinsertion. Update is automatically queued when the drawable's scene node moves or changes scale.
     void MarkForUpdate();
 
     /// Return local space bounding box. May not be applicable or properly updated on all drawables.
-    /// @property
     const BoundingBox& GetBoundingBox() const { return boundingBox_; }
 
     /// Return world-space bounding box.
-    /// @property
     const BoundingBox& GetWorldBoundingBox();
 
     /// Return drawable type.
     DrawableTypes GetDrawableType() const { return drawableType_; }
 
     /// Return draw distance.
-    /// @property
     float GetDrawDistance() const { return drawDistance_; }
 
     /// Return shadow draw distance.
-    /// @property
     float GetShadowDistance() const { return shadowDistance_; }
 
     /// Return LOD bias.
-    /// @property
     float GetLodBias() const { return lodBias_; }
 
     /// Return view mask.
-    /// @property
     mask32 GetViewMask() const { return viewMask_; }
 
     /// Return light mask.
-    /// @property
     mask32 GetLightMask() const { return lightMask_; }
 
     /// Return shadow mask.
-    /// @property
     mask32 GetShadowMask() const { return shadowMask_; }
 
     /// Return zone mask.
-    /// @property
     mask32 GetZoneMask() const { return zoneMask_; }
 
     /// Return maximum number of per-pixel lights.
-    /// @property
     i32 GetMaxLights() const { return maxLights_; }
 
     /// Return shadowcaster flag.
-    /// @property
     bool GetCastShadows() const { return castShadows_; }
 
     /// Return occluder flag.
-    /// @property
     bool IsOccluder() const { return occluder_; }
 
     /// Return occludee flag.
-    /// @property
     bool IsOccludee() const { return occludee_; }
 
     /// Return whether is in view this frame from any viewport camera. Excludes shadow map cameras.
-    /// @property
     bool IsInView() const;
     /// Return whether is in view of a specific camera this frame. Pass in a null camera to allow any camera, including shadow map cameras.
     bool IsInView(Camera* camera) const;
@@ -268,7 +243,6 @@ public:
     Octant* GetOctant() const { return octant_; }
 
     /// Return current zone.
-    /// @property
     Zone* GetZone() const { return zone_; }
 
     /// Return whether current zone is inconclusive or dirty due to the drawable moving.

--- a/source/dviglo/graphics/geometry.h
+++ b/source/dviglo/graphics/geometry.h
@@ -56,7 +56,6 @@ public:
     i32 GetNumVertexBuffers() const { return vertexBuffers_.Size(); }
 
     /// Return vertex buffer by index.
-    /// @property{get_vertexBuffers}
     VertexBuffer* GetVertexBuffer(i32 index) const;
 
     /// Return the index buffer.

--- a/source/dviglo/graphics/geometry.h
+++ b/source/dviglo/graphics/geometry.h
@@ -28,12 +28,10 @@ public:
     ~Geometry() override;
 
     /// Set number of vertex buffers.
-    /// @property
     bool SetNumVertexBuffers(i32 num);
     /// Set a vertex buffer by index.
     bool SetVertexBuffer(i32 index, VertexBuffer* buffer);
     /// Set the index buffer.
-    /// @property
     void SetIndexBuffer(IndexBuffer* buffer);
     /// Set the draw range.
     bool SetDrawRange(PrimitiveType type, i32 indexStart, i32 indexCount, bool getUsedVertexRange = true);
@@ -41,7 +39,6 @@ public:
     bool SetDrawRange(PrimitiveType type, i32 indexStart, i32 indexCount, i32 vertexStart, i32 vertexCount,
         bool checkIllegal = true);
     /// Set the LOD distance.
-    /// @property
     void SetLodDistance(float distance);
     /// Override raw vertex data to be returned for CPU-side operations.
     void SetRawVertexData(const SharedArrayPtr<byte>& data, const Vector<VertexElement>& elements);
@@ -56,7 +53,6 @@ public:
     const Vector<SharedPtr<VertexBuffer>>& GetVertexBuffers() const { return vertexBuffers_; }
 
     /// Return number of vertex buffers.
-    /// @property
     i32 GetNumVertexBuffers() const { return vertexBuffers_.Size(); }
 
     /// Return vertex buffer by index.
@@ -64,31 +60,24 @@ public:
     VertexBuffer* GetVertexBuffer(i32 index) const;
 
     /// Return the index buffer.
-    /// @property
     IndexBuffer* GetIndexBuffer() const { return indexBuffer_; }
 
     /// Return primitive type.
-    /// @property
     PrimitiveType GetPrimitiveType() const { return primitiveType_; }
 
     /// Return start index.
-    /// @property
     i32 GetIndexStart() const { return indexStart_; }
 
     /// Return number of indices.
-    /// @property
     i32 GetIndexCount() const { return indexCount_; }
 
     /// Return first used vertex.
-    /// @property
     i32 GetVertexStart() const { return vertexStart_; }
 
     /// Return number of used vertices.
-    /// @property
     i32 GetVertexCount() const { return vertexCount_; }
 
     /// Return LOD distance.
-    /// @property
     float GetLodDistance() const { return lodDistance_; }
 
     /// Return buffers' combined hash value for state sorting.
@@ -104,7 +93,6 @@ public:
     bool IsInside(const Ray& ray) const;
 
     /// Return whether has empty draw range.
-    /// @property
     bool IsEmpty() const { return indexCount_ == 0 && vertexCount_ == 0; }
 
 private:

--- a/source/dviglo/graphics/graphics.h
+++ b/source/dviglo/graphics/graphics.h
@@ -147,13 +147,10 @@ public:
     /// Set external window handle. Only effective before setting the initial screen mode.
     void SetExternalWindow(void* window);
     /// Set window title.
-    /// @property
     void SetWindowTitle(const String& windowTitle);
     /// Set window icon.
-    /// @property
     void SetWindowIcon(Image* windowIcon);
     /// Set window position. Sets initial position if window is not created yet.
-    /// @property
     void SetWindowPosition(const IntVector2& position);
     /// Set window position. Sets initial position if window is not created yet.
     void SetWindowPosition(int x, int y);
@@ -174,18 +171,14 @@ public:
     /// Set screen resolution only. Deprecated. Return true if successful.
     bool SetMode(int width, int height);
     /// Set whether the main window uses sRGB conversion on write.
-    /// @property
     void SetSRGB(bool enable);
     /// Set whether rendering output is dithered. Default true on OpenGL. No effect on Direct3D.
-    /// @property
     void SetDither(bool enable);
     /// Set whether to flush the GPU command buffer to prevent multiple frames being queued and uneven frame timesteps. Default off, may decrease performance if enabled. Not currently implemented on OpenGL.
-    /// @property
     void SetFlushGPU(bool enable);
     /// Set forced use of OpenGL 2 even if OpenGL 3 is available. Must be called before setting the screen mode for the first time. Default false. No effect on Direct3D9 & 11.
     void SetForceGL2(bool enable);
     /// Set allowed screen orientations as a space-separated list of "LandscapeLeft", "LandscapeRight", "Portrait" and "PortraitUpsideDown". Affects currently only iOS platform.
-    /// @property
     void SetOrientations(const String& orientations);
     /// Toggle between full screen and windowed mode. Return true if successful.
     bool ToggleFullscreen();
@@ -320,11 +313,9 @@ public:
     /// Precache shader variations from an XML file generated with BeginDumpShaders().
     void PrecacheShaders(Deserializer& source);
     /// Set shader cache directory, Direct3D only. This can either be an absolute path or a path within the resource system.
-    /// @property
     void SetShaderCacheDir(const String& path);
 
     /// Return whether rendering initialized.
-    /// @property
     bool IsInitialized() const;
 
 #ifdef URHO3D_OPENGL
@@ -352,53 +343,42 @@ public:
     SDL_Window* GetWindow() const { return window_; }
 
     /// Return window title.
-    /// @property
     const String& GetWindowTitle() const { return windowTitle_; }
 
     /// Return graphics API name.
-    /// @property
     const String& GetApiName() const { return apiName_; }
 
     /// Return window position.
-    /// @property
     IntVector2 GetWindowPosition() const;
 
     /// Return window width in pixels.
-    /// @property
     int GetWidth() const { return width_; }
 
     /// Return window height in pixels.
-    /// @property
     int GetHeight() const { return height_; }
 
     /// Return screen mode parameters.
     const ScreenModeParams& GetScreenModeParams() const { return screenParams_; }
 
     /// Return multisample mode (1 = no multisampling).
-    /// @property
     int GetMultiSample() const { return screenParams_.multiSample_; }
 
     /// Return window size in pixels.
-    /// @property
     IntVector2 GetSize() const { return IntVector2(width_, height_); }
 
     /// Return whether window is fullscreen.
-    /// @property
     bool GetFullscreen() const { return screenParams_.fullscreen_; }
 
     /// Return whether window is borderless.
-    /// @property
     bool GetBorderless() const { return screenParams_.borderless_; }
 
     /// Return whether window is resizable.
-    /// @property
     bool GetResizable() const { return screenParams_.resizable_; }
 
     /// Return whether window is high DPI.
     bool GetHighDPI() const { return screenParams_.highDPI_; }
 
     /// Return whether vertical sync is on.
-    /// @property
     bool GetVSync() const { return screenParams_.vsync_; }
 
     /// Return refresh rate when using vsync in fullscreen
@@ -408,38 +388,30 @@ public:
     int GetMonitor() const { return screenParams_.monitor_; }
 
     /// Return whether triple buffering is enabled.
-    /// @property
     bool GetTripleBuffer() const { return screenParams_.tripleBuffer_; }
 
     /// Return whether the main window is using sRGB conversion on write.
-    /// @property
     bool GetSRGB() const { return sRGB_; }
 
     /// Return whether rendering output is dithered. Always false on Direct3D.
-    /// @property
     bool GetDither() const;
 
     /// Return whether the GPU command buffer is flushed each frame.
-    /// @property
     bool GetFlushGPU() const { return flushGPU_; }
 
     /// Return whether OpenGL 2 use is forced. Effective only on OpenGL.
     bool GetForceGL2() const { return forceGL2_; }
 
     /// Return allowed screen orientations.
-    /// @property
     const String& GetOrientations() const { return orientations_; }
 
     /// Return whether graphics context is lost and can not render or load GPU resources.
-    /// @property
     bool IsDeviceLost() const;
 
     /// Return number of primitives drawn this frame.
-    /// @property
     unsigned GetNumPrimitives() const { return numPrimitives_; }
 
     /// Return number of batches drawn this frame.
-    /// @property
     unsigned GetNumBatches() const { return numBatches_; }
 
     /// Return dummy color texture format for shadow maps. Is "NULL" (consume no video memory) if supported.
@@ -452,58 +424,44 @@ public:
     unsigned GetHiresShadowMapFormat() const { return hiresShadowMapFormat_; }
 
     /// Return whether hardware instancing is supported.
-    /// @property
     bool GetInstancingSupport() const { return instancingSupport_; }
 
     /// Return whether light pre-pass rendering is supported.
-    /// @property
     bool GetLightPrepassSupport() const { return lightPrepassSupport_; }
 
     /// Return whether deferred rendering is supported.
-    /// @property
     bool GetDeferredSupport() const { return deferredSupport_; }
 
     /// Return whether anisotropic texture filtering is supported.
     bool GetAnisotropySupport() const { return anisotropySupport_; }
 
     /// Return whether shadow map depth compare is done in hardware.
-    /// @property
     bool GetHardwareShadowSupport() const { return hardwareShadowSupport_; }
 
     /// Return whether a readable hardware depth format is available.
-    /// @property
     bool GetReadableDepthSupport() const { return GetReadableDepthFormat() != 0; }
 
     /// Return whether sRGB conversion on texture sampling is supported.
-    /// @property
     bool GetSRGBSupport() const { return sRGBSupport_; }
 
     /// Return whether sRGB conversion on rendertarget writing is supported.
-    /// @property
     bool GetSRGBWriteSupport() const { return sRGBWriteSupport_; }
 
     /// Return supported fullscreen resolutions (third component is refreshRate). Will be empty if listing the resolutions is not supported on the platform (e.g. Web).
-    /// @property
     Vector<IntVector3> GetResolutions(int monitor) const;
     /// Return index of the best resolution for requested width, height and refresh rate.
     i32 FindBestResolutionIndex(int monitor, int width, int height, int refreshRate) const;
     /// Return supported multisampling levels.
-    /// @property
     Vector<int> GetMultiSampleLevels() const;
     /// Return the desktop resolution.
-    /// @property
     IntVector2 GetDesktopResolution(int monitor) const;
     /// Return the number of currently connected monitors.
-    /// @property
     int GetMonitorCount() const;
     /// Returns the index of the display containing the center of the window on success or a negative error code on failure.
-    /// @property
     int GetCurrentMonitor() const;
     /// Returns true if window is maximized or runs in full screen mode.
-    /// @property
     bool GetMaximized() const;
     /// Return display dpi information: (hdpi, vdpi, ddpi). On failure returns zero vector.
-    /// @property
     Vector3 GetDisplayDPI(int monitor=0) const;
 
     /// Return hardware format for a compressed image format, or 0 if unsupported.
@@ -630,7 +588,6 @@ public:
     bool GetUseClipPlane() const { return useClipPlane_; }
 
     /// Return shader cache directory, Direct3D only.
-    /// @property
     const String& GetShaderCacheDir() const { return shaderCacheDir_; }
 
     /// Return current rendertarget width and height.

--- a/source/dviglo/graphics/light.h
+++ b/source/dviglo/graphics/light.h
@@ -152,191 +152,139 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set light type.
-    /// @property
     void SetLightType(LightType type);
     /// Set vertex lighting mode.
-    /// @property
     void SetPerVertex(bool enable);
     /// Set color.
-    /// @property
     void SetColor(const Color& color);
     /// Set temperature of the light in Kelvin. Modulates the light color when "use physical values" is enabled.
-    /// @property
     void SetTemperature(float temperature);
     /// Set area light radius. Greater than zero activates area light mode. Works only with PBR shaders.
-    /// @property
     void SetRadius(float radius);
     /// Set tube area light length. Works only with PBR shaders.
-    /// @property
     void SetLength(float length);
     /// Set use physical light values.
-    /// @property
     void SetUsePhysicalValues(bool enable);
     /// Set specular intensity. Zero disables specular calculations.
-    /// @property
     void SetSpecularIntensity(float intensity);
     /// Set light brightness multiplier. Both the color and specular intensity are multiplied with this. When "use physical values" is enabled, the value is specified in lumens.
-    /// @property
     void SetBrightness(float brightness);
     /// Set range.
-    /// @property
     void SetRange(float range);
     /// Set spotlight field of view.
-    /// @property
     void SetFov(float fov);
     /// Set spotlight aspect ratio.
-    /// @property
     void SetAspectRatio(float aspectRatio);
     /// Set fade out start distance.
-    /// @property
     void SetFadeDistance(float distance);
     /// Set shadow fade out start distance. Only has effect if shadow distance is also non-zero.
-    /// @property
     void SetShadowFadeDistance(float distance);
     /// Set shadow depth bias parameters.
-    /// @property
     void SetShadowBias(const BiasParameters& parameters);
     /// Set directional light cascaded shadow parameters.
-    /// @property
     void SetShadowCascade(const CascadeParameters& parameters);
     /// Set shadow map focusing parameters.
-    /// @property
     void SetShadowFocus(const FocusParameters& parameters);
     /// Set light intensity in shadow between 0.0 - 1.0. 0.0 (the default) gives fully dark shadows.
-    /// @property
     void SetShadowIntensity(float intensity);
     /// Set shadow resolution between 0.25 - 1.0. Determines the shadow map to use.
-    /// @property
     void SetShadowResolution(float resolution);
     /// Set shadow camera near/far clip distance ratio for spot and point lights. Does not affect directional lights, since they are orthographic and have near clip 0.
-    /// @property
     void SetShadowNearFarRatio(float nearFarRatio);
     /// Set maximum shadow extrusion for directional lights. The actual extrusion will be the smaller of this and camera far clip. Default 1000.
-    /// @property
     void SetShadowMaxExtrusion(float extrusion);
     /// Set range attenuation texture.
-    /// @property
     void SetRampTexture(Texture* texture);
     /// Set spotlight attenuation texture.
-    /// @property
     void SetShapeTexture(Texture* texture);
 
     /// Return light type.
-    /// @property
     LightType GetLightType() const { return lightType_; }
 
     /// Return vertex lighting mode.
-    /// @property
     bool GetPerVertex() const { return perVertex_; }
 
     /// Return color.
-    /// @property
     const Color& GetColor() const { return color_; }
 
     /// Return the temperature of the light in Kelvin.
-    /// @property
     float GetTemperature() const { return temperature_; }
 
     /// Return area light mode radius. Works only with PBR shaders.
-    /// @property
     float GetRadius() const { return lightRad_; }
 
     /// Return area tube light length. Works only with PBR shaders.
-    /// @property
     float GetLength() const { return lightLength_; }
 
     /// Return if light uses temperature and brightness in lumens.
-    /// @property
     bool GetUsePhysicalValues() const { return usePhysicalValues_; }
 
     /// Return the color value of the temperature in Kelvin.
-    /// @property
     Color GetColorFromTemperature() const;
 
     /// Return specular intensity.
-    /// @property
     float GetSpecularIntensity() const { return specularIntensity_; }
 
     /// Return brightness multiplier. Specified in lumens when "use physical values" is enabled.
-    /// @property
     float GetBrightness() const { return brightness_; }
 
     /// Return effective color, multiplied by brightness and affected by temperature when "use physical values" is enabled. Alpha is always 1 so that can compare against the default black color to detect a light with no effect.
-    /// @property
     Color GetEffectiveColor() const;
 
     /// Return effective specular intensity, multiplied by absolute value of brightness.
-    /// @property
     float GetEffectiveSpecularIntensity() const { return specularIntensity_ * Abs(brightness_); }
 
     /// Return range.
-    /// @property
     float GetRange() const { return range_; }
 
     /// Return spotlight field of view.
-    /// @property
     float GetFov() const { return fov_; }
 
     /// Return spotlight aspect ratio.
-    /// @property
     float GetAspectRatio() const { return aspectRatio_; }
 
     /// Return fade start distance.
-    /// @property
     float GetFadeDistance() const { return fadeDistance_; }
 
     /// Return shadow fade start distance.
-    /// @property
     float GetShadowFadeDistance() const { return shadowFadeDistance_; }
 
     /// Return shadow depth bias parameters.
-    /// @property
     const BiasParameters& GetShadowBias() const { return shadowBias_; }
 
     /// Return directional light cascaded shadow parameters.
-    /// @property
     const CascadeParameters& GetShadowCascade() const { return shadowCascade_; }
 
     /// Return shadow map focus parameters.
-    /// @property
     const FocusParameters& GetShadowFocus() const { return shadowFocus_; }
 
     /// Return light intensity in shadow.
-    /// @property
     float GetShadowIntensity() const { return shadowIntensity_; }
 
     /// Return shadow resolution.
-    /// @property
     float GetShadowResolution() const { return shadowResolution_; }
 
     /// Return shadow camera near/far clip distance ratio.
-    /// @property
     float GetShadowNearFarRatio() const { return shadowNearFarRatio_; }
 
     /// Return maximum shadow extrusion distance for directional lights.
-    /// @property
     float GetShadowMaxExtrusion() const { return shadowMaxExtrusion_; }
 
     /// Return range attenuation texture.
-    /// @property
     Texture* GetRampTexture() const { return rampTexture_; }
 
     /// Return spotlight attenuation texture.
-    /// @property
     Texture* GetShapeTexture() const { return shapeTexture_; }
 
     /// Return spotlight frustum.
-    /// @property
     Frustum GetFrustum() const;
     /// Return spotlight frustum in the specified view space.
     Frustum GetViewSpaceFrustum(const Matrix3x4& view) const;
 
     /// Return number of shadow map cascade splits for a directional light, considering also graphics API limitations.
-    /// @property
     i32 GetNumShadowSplits() const;
 
     /// Return whether light has negative (darkening) color.
-    /// @property
     bool IsNegative() const { return GetEffectiveColor().SumRGB() < 0.0f; }
 
     /// Set sort value based on intensity and view distance.

--- a/source/dviglo/graphics/material.h
+++ b/source/dviglo/graphics/material.h
@@ -118,15 +118,12 @@ public:
     bool Save(JSONValue& dest) const;
 
     /// Set number of techniques.
-    /// @property
     void SetNumTechniques(i32 num);
     /// Set technique.
     void SetTechnique(i32 index, Technique* tech, MaterialQuality qualityLevel = QUALITY_LOW, float lodDistance = 0.0f);
     /// Set additional vertex shader defines. Separate multiple defines with spaces. Setting defines at the material level causes technique(s) to be cloned as necessary.
-    /// @property
     void SetVertexShaderDefines(const String& defines);
     /// Set additional pixel shader defines. Separate multiple defines with spaces. Setting defines at the material level causes technique(s) to be cloned as necessary.
-    /// @property
     void SetPixelShaderDefines(const String& defines);
     /// Set shader parameter.
     /// @property{set_shaderParameters}
@@ -146,31 +143,22 @@ public:
     /// Set texture coordinate transform.
     void SetUVTransform(const Vector2& offset, float rotation, float repeat);
     /// Set culling mode.
-    /// @property
     void SetCullMode(CullMode mode);
     /// Set culling mode for shadows.
-    /// @property
     void SetShadowCullMode(CullMode mode);
     /// Set polygon fill mode. Interacts with the camera's fill mode setting so that the "least filled" mode will be used.
-    /// @property
     void SetFillMode(FillMode mode);
     /// Set depth bias parameters for depth write and compare. Note that the normal offset parameter is not used and will not be saved, as it affects only shadow map sampling during light rendering.
-    /// @property
     void SetDepthBias(const BiasParameters& parameters);
     /// Set alpha-to-coverage mode on all passes.
-    /// @property
     void SetAlphaToCoverage(bool enable);
     /// Set line antialiasing on/off. Has effect only on models that consist of line lists.
-    /// @property
     void SetLineAntiAlias(bool enable);
     /// Set 8-bit render order within pass. Default 0. Lower values will render earlier and higher values later, taking precedence over e.g. state and distance sorting.
-    /// @property
     void SetRenderOrder(i8 order);
     /// Set whether to use in occlusion rendering. Default true.
-    /// @property
     void SetOcclusion(bool enable);
     /// Associate the material with a scene to ensure that shader parameter animation happens in sync with scene update, respecting the scene time scale. If no scene is set, the global update events will be used.
-    /// @property
     void SetScene(Scene* scene);
     /// Remove shader parameter.
     void RemoveShaderParameter(const String& name);
@@ -184,7 +172,6 @@ public:
     void MarkForAuxView(i32 frameNumber);
 
     /// Return number of techniques.
-    /// @property
     i32 GetNumTechniques() const { return techniques_.Size(); }
 
     /// Return all techniques.
@@ -205,10 +192,8 @@ public:
     const HashMap<TextureUnit, SharedPtr<Texture>>& GetTextures() const { return textures_; }
 
     /// Return additional vertex shader defines.
-    /// @property
     const String& GetVertexShaderDefines() const { return vertexShaderDefines_; }
     /// Return additional pixel shader defines.
-    /// @property
     const String& GetPixelShaderDefines() const { return pixelShaderDefines_; }
 
     /// Return shader parameter.
@@ -225,45 +210,36 @@ public:
     const HashMap<StringHash, MaterialShaderParameter>& GetShaderParameters() const { return shaderParameters_; }
 
     /// Return normal culling mode.
-    /// @property
     CullMode GetCullMode() const { return cullMode_; }
 
     /// Return culling mode for shadows.
-    /// @property
     CullMode GetShadowCullMode() const { return shadowCullMode_; }
 
     /// Return polygon fill mode.
-    /// @property
     FillMode GetFillMode() const { return fillMode_; }
 
     /// Return depth bias.
-    /// @property
     const BiasParameters& GetDepthBias() const { return depthBias_; }
 
     /// Return alpha-to-coverage mode.
-    /// @property
     bool GetAlphaToCoverage() const { return alphaToCoverage_; }
 
     /// Return whether line antialiasing is enabled.
-    /// @property
     bool GetLineAntiAlias() const { return lineAntiAlias_; }
 
     /// Return render order.
-    /// @property
     i8 GetRenderOrder() const { return renderOrder_; }
 
     /// Return last auxiliary view rendered frame number.
     i32 GetAuxViewFrameNumber() const { return auxViewFrameNumber_; }
 
     /// Return whether should render occlusion.
-    /// @property
     bool GetOcclusion() const { return occlusion_; }
 
     /// Return whether should render specular.
     bool GetSpecular() const { return specular_; }
 
     /// Return the scene associated with the material for shader parameter animation updates.
-    /// @property
     Scene* GetScene() const;
 
     /// Return shader parameter hash value. Used as an optimization to avoid setting shader parameters unnecessarily.

--- a/source/dviglo/graphics/material.h
+++ b/source/dviglo/graphics/material.h
@@ -126,7 +126,6 @@ public:
     /// Set additional pixel shader defines. Separate multiple defines with spaces. Setting defines at the material level causes technique(s) to be cloned as necessary.
     void SetPixelShaderDefines(const String& defines);
     /// Set shader parameter.
-    /// @property{set_shaderParameters}
     void SetShaderParameter(const String& name, const Variant& value);
     /// Set shader parameter animation.
     void
@@ -136,7 +135,6 @@ public:
     /// Set shader parameter animation speed.
     void SetShaderParameterAnimationSpeed(const String& name, float speed);
     /// Set texture.
-    /// @property{set_textures}
     void SetTexture(TextureUnit unit, Texture* texture);
     /// Set texture coordinate transform.
     void SetUVTransform(const Vector2& offset, float rotation, const Vector2& repeat);
@@ -180,12 +178,10 @@ public:
     /// Return technique entry by index.
     const TechniqueEntry& GetTechniqueEntry(i32 index) const;
     /// Return technique by index.
-    /// @property{get_techniques}
     Technique* GetTechnique(i32 index) const;
     /// Return pass by technique index and pass name.
     Pass* GetPass(i32 index, const String& passName) const;
     /// Return texture by unit.
-    /// @property{get_textures}
     Texture* GetTexture(TextureUnit unit) const;
 
     /// Return all textures.
@@ -197,7 +193,6 @@ public:
     const String& GetPixelShaderDefines() const { return pixelShaderDefines_; }
 
     /// Return shader parameter.
-    /// @property{get_shaderParameters}
     const Variant& GetShaderParameter(const String& name) const;
     /// Return shader parameter animation.
     ValueAnimation* GetShaderParameterAnimation(const String& name) const;

--- a/source/dviglo/graphics/model.h
+++ b/source/dviglo/graphics/model.h
@@ -121,7 +121,6 @@ public:
     /// Set geometry.
     bool SetGeometry(i32 index, i32 lodLevel, Geometry* geometry);
     /// Set geometry center.
-    /// @property{set_geometryCenters}
     bool SetGeometryCenter(i32 index, const Vector3& center);
     /// Set skeleton.
     void SetSkeleton(const Skeleton& skeleton);
@@ -160,7 +159,6 @@ public:
     Geometry* GetGeometry(i32 index, i32 lodLevel) const;
 
     /// Return geometry center by index.
-    /// @property{get_geometryCenters}
     const Vector3& GetGeometryCenter(i32 index) const
     {
         assert(index >= 0);

--- a/source/dviglo/graphics/model.h
+++ b/source/dviglo/graphics/model.h
@@ -108,7 +108,6 @@ public:
     bool Save(Serializer& dest) const override;
 
     /// Set local-space bounding box.
-    /// @property
     void SetBoundingBox(const BoundingBox& box);
     /// Set vertex buffers and their morph ranges.
     bool SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const Vector<i32>& morphRangeStarts,
@@ -116,10 +115,8 @@ public:
     /// Set index buffers.
     bool SetIndexBuffers(const Vector<SharedPtr<IndexBuffer>>& buffers);
     /// Set number of geometries.
-    /// @property
     void SetNumGeometries(i32 num);
     /// Set number of LOD levels in a geometry.
-    /// @property
     bool SetNumGeometryLodLevels(i32 index, i32 num);
     /// Set geometry.
     bool SetGeometry(i32 index, i32 lodLevel, Geometry* geometry);
@@ -136,11 +133,9 @@ public:
     SharedPtr<Model> Clone(const String& cloneName = String::EMPTY) const;
 
     /// Return bounding box.
-    /// @property
     const BoundingBox& GetBoundingBox() const { return boundingBox_; }
 
     /// Return skeleton.
-    /// @property
     Skeleton& GetSkeleton() { return skeleton_; }
 
     /// Return vertex buffers.
@@ -150,11 +145,9 @@ public:
     const Vector<SharedPtr<IndexBuffer>>& GetIndexBuffers() const { return indexBuffers_; }
 
     /// Return number of geometries.
-    /// @property
     i32 GetNumGeometries() const { return geometries_.Size(); }
 
     /// Return number of LOD levels in geometry.
-    /// @property
     i32 GetNumGeometryLodLevels(i32 index) const;
 
     /// Return geometry pointers.
@@ -181,7 +174,6 @@ public:
     const Vector<ModelMorph>& GetMorphs() const { return morphs_; }
 
     /// Return number of vertex morphs.
-    /// @property
     i32 GetNumMorphs() const { return morphs_.Size(); }
 
     /// Return vertex morph by index.

--- a/source/dviglo/graphics/octree.h
+++ b/source/dviglo/graphics/octree.h
@@ -55,7 +55,6 @@ public:
     }
 
     /// Return world-space bounding box.
-    /// @property
     const BoundingBox& GetWorldBoundingBox() const { return worldBoundingBox_; }
 
     /// Return bounding box used for fitting drawable objects.
@@ -175,7 +174,6 @@ public:
     void RaycastSingle(RayOctreeQuery& query) const;
 
     /// Return subdivision levels.
-    /// @property
     i32 GetNumLevels() const { return numLevels_; }
 
     /// Mark drawable object as requiring an update and a reinsertion.

--- a/source/dviglo/graphics/particle_effect.h
+++ b/source/dviglo/graphics/particle_effect.h
@@ -116,97 +116,66 @@ public:
     /// Load resource from XMLElement synchronously. Return true if successful.
     bool Load(const XMLElement& source);
     /// Set material.
-    /// @property
     void SetMaterial(Material* material);
     /// Set maximum number of particles.
-    /// @property
     void SetNumParticles(unsigned num);
     /// Set whether to update when particles are not visible.
-    /// @property
     void SetUpdateInvisible(bool enable);
     /// Set whether billboards are relative to the scene node.
-    /// @property
     void SetRelative(bool enable);
     /// Set whether scene node scale affects billboards' size.
-    /// @property
     void SetScaled(bool enable);
     /// Set whether billboards are sorted by distance.
-    /// @property
     void SetSorted(bool enable);
     /// Set whether billboards have fixed size on screen (measured in pixels) regardless of distance to camera.
-    /// @property
     void SetFixedScreenSize(bool enable);
     /// Set animation LOD bias.
-    /// @property
     void SetAnimationLodBias(float lodBias);
     /// Set emitter type.
-    /// @property
     void SetEmitterType(EmitterType type);
     /// Set emitter size.
-    /// @property
     void SetEmitterSize(const Vector3& size);
     /// Set negative direction limit.
-    /// @property
     void SetMinDirection(const Vector3& direction);
     /// Set positive direction limit.
-    /// @property
     void SetMaxDirection(const Vector3& direction);
     /// Set constant force acting on particles.
-    /// @property
     void SetConstantForce(const Vector3& force);
     /// Set particle velocity damping force.
-    /// @property
     void SetDampingForce(float force);
     /// Set emission active period length (0 = infinite).
-    /// @property
     void SetActiveTime(float time);
     /// Set emission inactive period length (0 = infinite).
-    /// @property
     void SetInactiveTime(float time);
     /// Set minimum emission rate.
-    /// @property
     void SetMinEmissionRate(float rate);
     /// Set maximum emission rate.
-    /// @property
     void SetMaxEmissionRate(float rate);
     /// Set particle minimum size.
-    /// @property
     void SetMinParticleSize(const Vector2& size);
     /// Set particle maximum size.
-    /// @property
     void SetMaxParticleSize(const Vector2& size);
     /// Set particle minimum time to live.
-    /// @property
     void SetMinTimeToLive(float time);
     /// Set particle maximum time to live.
-    /// @property
     void SetMaxTimeToLive(float time);
     /// Set particle minimum velocity.
-    /// @property
     void SetMinVelocity(float velocity);
     /// Set particle maximum velocity.
-    /// @property
     void SetMaxVelocity(float velocity);
     /// Set particle minimum rotation.
-    /// @property
     void SetMinRotation(float rotation);
     /// Set particle maximum rotation.
-    /// @property
     void SetMaxRotation(float rotation);
     /// Set particle minimum rotation speed.
-    /// @property
     void SetMinRotationSpeed(float speed);
     /// Set particle maximum rotation speed.
-    /// @property
     void SetMaxRotationSpeed(float speed);
     /// Set particle size additive modifier.
-    /// @property
     void SetSizeAdd(float sizeAdd);
     /// Set particle size multiplicative modifier.
-    /// @property
     void SetSizeMul(float sizeMul);
     /// Set how the particles should rotate in relation to the camera. Default is to follow camera rotation on all axes (FC_ROTATE_XYZ).
-    /// @property
     void SetFaceCameraMode(FaceCameraMode mode);
 
     /// Add a color frame sorted in the correct position based on time.
@@ -221,7 +190,6 @@ public:
     /// Set color animation frame at index. If index is greater than number of color frames, new color frames are added.
     void SetColorFrame(unsigned index, const ColorFrame& colorFrame);
     /// Set number of color frames.
-    /// @property
     void SetNumColorFrames(unsigned number);
     /// Sort the list of color frames based on time.
     void SortColorFrames();
@@ -238,7 +206,6 @@ public:
     /// Set number of texture animation frames.
     void SetTextureFrame(unsigned index, const TextureFrame& textureFrame);
     /// Set number of texture frames.
-    /// @property
     void SetNumTextureFrames(unsigned number);
     /// Sort the list of texture frames based on time.
     void SortTextureFrames();
@@ -246,123 +213,93 @@ public:
     SharedPtr<ParticleEffect> Clone(const String& cloneName = String::EMPTY) const;
 
     /// Return material.
-    /// @property
     Material* GetMaterial() const { return material_; }
 
     /// Return maximum number of particles.
-    /// @property
     unsigned GetNumParticles() const { return numParticles_; }
 
     /// Return whether to update when particles are not visible.
-    /// @property
     bool GetUpdateInvisible() const { return updateInvisible_; }
 
     /// Return whether billboards are relative to the scene node.
-    /// @property
     bool IsRelative() const { return relative_; }
 
     /// Return whether scene node scale affects billboards' size.
-    /// @property
     bool IsScaled() const { return scaled_; }
 
     /// Return whether billboards are sorted.
-    /// @property
     bool IsSorted() const { return sorted_; }
 
     /// Return whether billboards are fixed screen size.
-    /// @property
     bool IsFixedScreenSize() const { return fixedScreenSize_; }
 
     /// Return animation Lod bias.
-    /// @property
     float GetAnimationLodBias() const { return animationLodBias_; }
 
     /// Return emitter type.
-    /// @property
     EmitterType GetEmitterType() const { return emitterType_; }
 
     /// Return emitter size.
-    /// @property
     const Vector3& GetEmitterSize() const { return emitterSize_; }
 
     /// Return negative direction limit.
-    /// @property
     const Vector3& GetMinDirection() const { return directionMin_; }
 
     /// Return positive direction limit.
-    /// @property
     const Vector3& GetMaxDirection() const { return directionMax_; }
 
     /// Return constant force acting on particles.
-    /// @property
     const Vector3& GetConstantForce() const { return constantForce_; }
 
     /// Return particle velocity damping force.
-    /// @property
     float GetDampingForce() const { return dampingForce_; }
 
     /// Return emission active period length (0 = infinite).
-    /// @property
     float GetActiveTime() const { return activeTime_; }
 
     /// Return emission inactive period length (0 = infinite).
-    /// @property
     float GetInactiveTime() const { return inactiveTime_; }
 
     /// Return minimum emission rate.
-    /// @property
     float GetMinEmissionRate() const { return emissionRateMin_; }
 
     /// Return maximum emission rate.
-    /// @property
     float GetMaxEmissionRate() const { return emissionRateMax_; }
 
     /// Return particle minimum size.
-    /// @property
     const Vector2& GetMinParticleSize() const { return sizeMin_; }
 
     /// Return particle maximum size.
-    /// @property
     const Vector2& GetMaxParticleSize() const { return sizeMax_; }
 
     /// Return particle minimum time to live.
-    /// @property
     float GetMinTimeToLive() const { return timeToLiveMin_; }
 
     /// Return particle maximum time to live.
-    /// @property
     float GetMaxTimeToLive() const { return timeToLiveMax_; }
 
     /// Return particle minimum velocity.
-    /// @property
     float GetMinVelocity() const { return velocityMin_; }
 
     /// Return particle maximum velocity.
-    /// @property
     float GetMaxVelocity() const { return velocityMax_; }
 
     /// Return particle minimum rotation.
-    /// @property
     float GetMinRotation() const { return rotationMin_; }
 
     /// Return particle maximum rotation.
-    /// @property
     float GetMaxRotation() const { return rotationMax_; }
 
     /// Return particle minimum rotation speed.
-    /// @property
     float GetMinRotationSpeed() const { return rotationSpeedMin_; }
 
     /// Return particle maximum rotation speed.
-    /// @property
     float GetMaxRotationSpeed() const { return rotationSpeedMax_; }
 
     /// Return particle size additive modifier.
-    /// @property
     float GetSizeAdd() const { return sizeAdd_; }
 
     /// Return particle size multiplicative modifier.
-    /// @property
     float GetSizeMul() const { return sizeMul_; }
 
     /// Return all color animation frames.
@@ -370,7 +307,6 @@ public:
     const Vector<ColorFrame>& GetColorFrames() const { return colorFrames_; }
 
     /// Return number of color animation frames.
-    /// @property
     unsigned GetNumColorFrames() const { return colorFrames_.Size(); }
 
     /// Return a color animation frame, or null if outside range.
@@ -381,14 +317,12 @@ public:
     const Vector<TextureFrame>& GetTextureFrames() const { return textureFrames_; }
 
     /// Return number of texture animation frames.
-    /// @property
     unsigned GetNumTextureFrames() const { return textureFrames_.Size(); }
 
     /// Return a texture animation frame, or null if outside range.
     const TextureFrame* GetTextureFrame(unsigned index) const;
 
     /// Return how the particles rotate in relation to the camera.
-    /// @property
     FaceCameraMode GetFaceCameraMode() const { return faceCameraMode_; }
 
     /// Return random direction.

--- a/source/dviglo/graphics/particle_emitter.h
+++ b/source/dviglo/graphics/particle_emitter.h
@@ -52,19 +52,14 @@ public:
     void Update(const FrameInfo& frame) override;
 
     /// Set particle effect.
-    /// @property
     void SetEffect(ParticleEffect* effect);
     /// Set maximum number of particles.
-    /// @property
     void SetNumParticles(i32 num);
     /// Set whether should be emitting. If the state was changed, also resets the emission period timer.
-    /// @property
     void SetEmitting(bool enable);
     /// Set whether particles should be serialized. Default true, set false to reduce scene file size.
-    /// @property
     void SetSerializeParticles(bool enable);
     /// Set to remove either the emitter component or its owner node from the scene automatically on particle effect completion. Disabled by default.
-    /// @property
     void SetAutoRemoveMode(AutoRemoveMode mode);
     /// Reset the emission period timer.
     void ResetEmissionTimer();
@@ -76,23 +71,18 @@ public:
     void ApplyEffect();
 
     /// Return particle effect.
-    /// @property
     ParticleEffect* GetEffect() const;
 
     /// Return maximum number of particles.
-    /// @property
     i32 GetNumParticles() const { return particles_.Size(); }
 
     /// Return whether is currently emitting.
-    /// @property
     bool IsEmitting() const { return emitting_; }
 
     /// Return whether particles are to be serialized.
-    /// @property
     bool GetSerializeParticles() const { return serializeParticles_; }
 
     /// Return automatic removal mode on particle effect completion.
-    /// @property
     AutoRemoveMode GetAutoRemoveMode() const { return autoRemove_; }
 
     /// Set particles effect attribute.

--- a/source/dviglo/graphics/render_path.h
+++ b/source/dviglo/graphics/render_path.h
@@ -86,10 +86,8 @@ struct URHO3D_API RenderPathCommand
     /// Read from an XML element.
     void Load(const XMLElement& element);
     /// Set a texture resource name. Can also refer to a rendertarget defined in the rendering path.
-    /// @property{set_textureNames}
     void SetTextureName(TextureUnit unit, const String& name);
     /// Set a shader parameter.
-    /// @property{set_shaderParameters}
     void SetShaderParameter(const String& name, const Variant& value);
     /// Remove a shader parameter.
     void RemoveShaderParameter(const String& name);
@@ -98,29 +96,23 @@ struct URHO3D_API RenderPathCommand
     /// Set output rendertarget name and face index for cube maps.
     void SetOutput(i32 index, const String& name, CubeMapFace face = FACE_POSITIVE_X);
     /// Set output rendertarget name.
-    /// @property{set_outputNames}
     void SetOutputName(i32 index, const String& name);
     /// Set output rendertarget face index for cube maps.
-    /// @property{set_outputFaces}
     void SetOutputFace(i32 index, CubeMapFace face);
     /// Set depth-stencil output name. When empty, will assign a depth-stencil buffer automatically.
     void SetDepthStencilName(const String& name);
 
     /// Return texture resource name.
-    /// @property{get_textureNames}
     const String& GetTextureName(TextureUnit unit) const;
     /// Return shader parameter.
-    /// @property{get_shaderParameters}
     const Variant& GetShaderParameter(const String& name) const;
 
     /// Return number of output rendertargets.
     i32 GetNumOutputs() const { return outputs_.Size(); }
 
     /// Return output rendertarget name.
-    /// @property{get_outputNames}
     const String& GetOutputName(i32 index) const;
     /// Return output rendertarget face index.
-    /// @property{get_outputFaces}
     CubeMapFace GetOutputFace(i32 index) const;
 
     /// Return depth-stencil output name.
@@ -202,7 +194,6 @@ public:
     /// Toggle enabled state of commands and rendertargets by tag.
     void ToggleEnabled(const String& tag);
     /// Assign rendertarget at index.
-    /// @property{set_renderTargets}
     void SetRenderTarget(unsigned index, const RenderTargetInfo& info);
     /// Add a rendertarget.
     void AddRenderTarget(const RenderTargetInfo& info);
@@ -213,7 +204,6 @@ public:
     /// Remove rendertargets by tag name.
     void RemoveRenderTargets(const String& tag);
     /// Assign command at index.
-    /// @property{set_commands}
     void SetCommand(unsigned index, const RenderPathCommand& command);
     /// Add a command to the end of the list.
     void AddCommand(const RenderPathCommand& command);
@@ -224,7 +214,6 @@ public:
     /// Remove commands by tag name.
     void RemoveCommands(const String& tag);
     /// Set a shader parameter in all commands that define it.
-    /// @property{set_shaderParameters}
     void SetShaderParameter(const String& name, const Variant& value);
 
     /// Return number of rendertargets.
@@ -241,7 +230,6 @@ public:
     }
 
     /// Return a shader parameter (first appearance in any command).
-    /// @property{get_shaderParameters}
     const Variant& GetShaderParameter(const String& name) const;
 
     /// Rendertargets.

--- a/source/dviglo/graphics/render_path.h
+++ b/source/dviglo/graphics/render_path.h
@@ -94,7 +94,6 @@ struct URHO3D_API RenderPathCommand
     /// Remove a shader parameter.
     void RemoveShaderParameter(const String& name);
     /// Set number of output rendertargets.
-    /// @property
     void SetNumOutputs(i32 num);
     /// Set output rendertarget name and face index for cube maps.
     void SetOutput(i32 index, const String& name, CubeMapFace face = FACE_POSITIVE_X);
@@ -105,7 +104,6 @@ struct URHO3D_API RenderPathCommand
     /// @property{set_outputFaces}
     void SetOutputFace(i32 index, CubeMapFace face);
     /// Set depth-stencil output name. When empty, will assign a depth-stencil buffer automatically.
-    /// @property
     void SetDepthStencilName(const String& name);
 
     /// Return texture resource name.
@@ -116,7 +114,6 @@ struct URHO3D_API RenderPathCommand
     const Variant& GetShaderParameter(const String& name) const;
 
     /// Return number of output rendertargets.
-    /// @property
     i32 GetNumOutputs() const { return outputs_.Size(); }
 
     /// Return output rendertarget name.
@@ -127,7 +124,6 @@ struct URHO3D_API RenderPathCommand
     CubeMapFace GetOutputFace(i32 index) const;
 
     /// Return depth-stencil output name.
-    /// @property
     const String& GetDepthStencilName() const { return depthStencilName_; }
 
     /// Tag name.
@@ -200,10 +196,8 @@ public:
     /// Enable/disable commands and rendertargets by tag.
     void SetEnabled(const String& tag, bool active);
     /// Return true of any of render targets or commands with specified tag are enabled.
-    /// @property
     bool IsEnabled(const String& tag) const;
     /// Return true if renderpath or command with given tag exists.
-    /// @property
     bool IsAdded(const String& tag) const;
     /// Toggle enabled state of commands and rendertargets by tag.
     void ToggleEnabled(const String& tag);
@@ -234,11 +228,9 @@ public:
     void SetShaderParameter(const String& name, const Variant& value);
 
     /// Return number of rendertargets.
-    /// @property
     i32 GetNumRenderTargets() const { return renderTargets_.Size(); }
 
     /// Return number of commands.
-    /// @property
     i32 GetNumCommands() const { return commands_.Size(); }
 
     /// Return command at index, or null if does not exist.

--- a/source/dviglo/graphics/renderer.h
+++ b/source/dviglo/graphics/renderer.h
@@ -169,7 +169,6 @@ public:
     /// Set number of backbuffer viewports to render.
     void SetNumViewports(i32 num);
     /// Set a backbuffer viewport.
-    /// @property{set_viewports}
     void SetViewport(i32 index, Viewport* viewport);
     /// Set default renderpath.
     void SetDefaultRenderPath(RenderPath* renderPath);
@@ -178,7 +177,6 @@ public:
     /// Set default non-textured material technique.
     void SetDefaultTechnique(Technique* technique);
     /// Set HDR rendering on/off.
-    /// @property{set_hdrRendering}
     void SetHDRRendering(bool enable);
     /// Set specular lighting on/off.
     void SetSpecularLighting(bool enable);
@@ -201,7 +199,6 @@ public:
     /// Set shadow parameters when VSM is used, they help to reduce light bleeding. LightBleeding must be in [0, 1].
     void SetVSMShadowParameters(float minVariance, float lightBleedingReduction);
     /// Set VSM shadow map multisampling level. Default 1 (no multisampling).
-    /// @property{set_vsmMultiSample}
     void SetVSMMultiSample(int multiSample);
     /// Set post processing filter to the shadow map.
     /// @nobind
@@ -242,7 +239,6 @@ public:
     i32 GetNumViewports() const { return viewports_.Size(); }
 
     /// Return backbuffer viewport by index.
-    /// @property{get_viewports}
     Viewport* GetViewport(i32 index) const;
     /// Return nth backbuffer viewport associated to a scene. Index 0 returns the first.
     Viewport* GetViewportForScene(Scene* scene, i32 index) const;
@@ -252,7 +248,6 @@ public:
     Technique* GetDefaultTechnique() const;
 
     /// Return whether HDR rendering is enabled.
-    /// @property{get_hdrRendering}
     bool GetHDRRendering() const { return hdrRendering_; }
 
     /// Return whether specular lighting is enabled.
@@ -283,11 +278,9 @@ public:
     float GetShadowSoftness() const { return shadowSoftness_; }
 
     /// Return VSM shadow parameters.
-    /// @property{get_vsmShadowParameters}
     Vector2 GetVSMShadowParameters() const { return vsmShadowParams_; };
 
     /// Return VSM shadow multisample level.
-    /// @property{get_vsmMultiSample}
     int GetVSMMultiSample() const { return vsmMultiSample_; }
 
     /// Return whether shadow maps are reused.

--- a/source/dviglo/graphics/renderer.h
+++ b/source/dviglo/graphics/renderer.h
@@ -167,48 +167,36 @@ public:
     ~Renderer() override;
 
     /// Set number of backbuffer viewports to render.
-    /// @property
     void SetNumViewports(i32 num);
     /// Set a backbuffer viewport.
     /// @property{set_viewports}
     void SetViewport(i32 index, Viewport* viewport);
     /// Set default renderpath.
-    /// @property
     void SetDefaultRenderPath(RenderPath* renderPath);
     /// Set default renderpath from an XML file.
     void SetDefaultRenderPath(XMLFile* xmlFile);
     /// Set default non-textured material technique.
-    /// @property
     void SetDefaultTechnique(Technique* technique);
     /// Set HDR rendering on/off.
     /// @property{set_hdrRendering}
     void SetHDRRendering(bool enable);
     /// Set specular lighting on/off.
-    /// @property
     void SetSpecularLighting(bool enable);
     /// Set default texture max anisotropy level.
-    /// @property
     void SetTextureAnisotropy(int level);
     /// Set default texture filtering.
-    /// @property
     void SetTextureFilterMode(TextureFilterMode mode);
     /// Set texture quality level. See the QUALITY constants in GraphicsDefs.h.
-    /// @property
     void SetTextureQuality(MaterialQuality quality);
     /// Set material quality level. See the QUALITY constants in GraphicsDefs.h.
-    /// @property
     void SetMaterialQuality(MaterialQuality quality);
     /// Set shadows on/off.
-    /// @property
     void SetDrawShadows(bool enable);
     /// Set shadow map resolution.
-    /// @property
     void SetShadowMapSize(int size);
     /// Set shadow quality mode. See the SHADOWQUALITY enum in GraphicsDefs.h.
-    /// @property
     void SetShadowQuality(ShadowQuality quality);
     /// Set shadow softness, only works when SHADOWQUALITY_BLUR_VSM is used.
-    /// @property
     void SetShadowSoftness(float shadowSoftness);
     /// Set shadow parameters when VSM is used, they help to reduce light bleeding. LightBleeding must be in [0, 1].
     void SetVSMShadowParameters(float minVariance, float lightBleedingReduction);
@@ -219,43 +207,30 @@ public:
     /// @nobind
     void SetShadowMapFilter(Object* instance, ShadowMapFilter functionPtr);
     /// Set reuse of shadow maps. Default is true. If disabled, also transparent geometry can be shadowed.
-    /// @property
     void SetReuseShadowMaps(bool enable);
     /// Set maximum number of shadow maps created for one resolution. Only has effect if reuse of shadow maps is disabled.
-    /// @property
     void SetMaxShadowMaps(int shadowMaps);
     /// Set dynamic instancing on/off. When on (default), drawables using the same static-type geometry and material will be automatically combined to an instanced draw call.
-    /// @property
     void SetDynamicInstancing(bool enable);
     /// Set number of extra instancing buffer elements. Default is 0. Extra 4-vectors are available through TEXCOORD7 and further.
-    /// @property
     void SetNumExtraInstancingBufferElements(int elements);
     /// Set minimum number of instances required in a batch group to render as instanced.
-    /// @property
     void SetMinInstances(int instances);
     /// Set maximum number of sorted instances per batch group. If exceeded, instances are rendered unsorted.
-    /// @property
     void SetMaxSortedInstances(int instances);
     /// Set maximum number of occluder triangles.
-    /// @property
     void SetMaxOccluderTriangles(int triangles);
     /// Set occluder buffer width.
-    /// @property
     void SetOcclusionBufferSize(int size);
     /// Set required screen size (1.0 = full screen) for occluders.
-    /// @property
     void SetOccluderSizeThreshold(float screenSize);
     /// Set whether to thread occluder rendering. Default false.
-    /// @property
     void SetThreadedOcclusion(bool enable);
     /// Set shadow depth bias multiplier for mobile platforms to counteract possible worse shadow map precision. Default 1.0 (no effect).
-    /// @property
     void SetMobileShadowBiasMul(float mul);
     /// Set shadow depth bias addition for mobile platforms to counteract possible worse shadow map precision. Default 0.0 (no effect).
-    /// @property
     void SetMobileShadowBiasAdd(float add);
     /// Set shadow normal offset multiplier for mobile platforms to counteract possible worse shadow map precision. Default 1.0 (no effect).
-    /// @property
     void SetMobileNormalOffsetMul(float mul);
     /// Force reload of shaders.
     void ReloadShaders();
@@ -264,7 +239,6 @@ public:
     void ApplyShadowMapFilter(View* view, Texture2D* shadowMap, float blurScale);
 
     /// Return number of backbuffer viewports.
-    /// @property
     i32 GetNumViewports() const { return viewports_.Size(); }
 
     /// Return backbuffer viewport by index.
@@ -273,10 +247,8 @@ public:
     /// Return nth backbuffer viewport associated to a scene. Index 0 returns the first.
     Viewport* GetViewportForScene(Scene* scene, i32 index) const;
     /// Return default renderpath.
-    /// @property
     RenderPath* GetDefaultRenderPath() const;
     /// Return default non-textured material technique.
-    /// @property
     Technique* GetDefaultTechnique() const;
 
     /// Return whether HDR rendering is enabled.
@@ -284,39 +256,30 @@ public:
     bool GetHDRRendering() const { return hdrRendering_; }
 
     /// Return whether specular lighting is enabled.
-    /// @property
     bool GetSpecularLighting() const { return specularLighting_; }
 
     /// Return whether drawing shadows is enabled.
-    /// @property
     bool GetDrawShadows() const { return drawShadows_; }
 
     /// Return default texture max. anisotropy level.
-    /// @property
     int GetTextureAnisotropy() const { return textureAnisotropy_; }
 
     /// Return default texture filtering mode.
-    /// @property
     TextureFilterMode GetTextureFilterMode() const { return textureFilterMode_; }
 
     /// Return texture quality level.
-    /// @property
     MaterialQuality GetTextureQuality() const { return textureQuality_; }
 
     /// Return material quality level.
-    /// @property
     MaterialQuality GetMaterialQuality() const { return materialQuality_; }
 
     /// Return shadow map resolution.
-    /// @property
     int GetShadowMapSize() const { return shadowMapSize_; }
 
     /// Return shadow quality.
-    /// @property
     ShadowQuality GetShadowQuality() const { return shadowQuality_; }
 
     /// Return shadow softness.
-    /// @property
     float GetShadowSoftness() const { return shadowSoftness_; }
 
     /// Return VSM shadow parameters.
@@ -328,96 +291,72 @@ public:
     int GetVSMMultiSample() const { return vsmMultiSample_; }
 
     /// Return whether shadow maps are reused.
-    /// @property
     bool GetReuseShadowMaps() const { return reuseShadowMaps_; }
 
     /// Return maximum number of shadow maps per resolution.
-    /// @property
     int GetMaxShadowMaps() const { return maxShadowMaps_; }
 
     /// Return whether dynamic instancing is in use.
-    /// @property
     bool GetDynamicInstancing() const { return dynamicInstancing_; }
 
     /// Return number of extra instancing buffer elements.
-    /// @property
     int GetNumExtraInstancingBufferElements() const { return numExtraInstancingBufferElements_; };
 
     /// Return minimum number of instances required in a batch group to render as instanced.
-    /// @property
     int GetMinInstances() const { return minInstances_; }
 
     /// Return maximum number of sorted instances per batch group.
-    /// @property
     int GetMaxSortedInstances() const { return maxSortedInstances_; }
 
     /// Return maximum number of occluder triangles.
-    /// @property
     int GetMaxOccluderTriangles() const { return maxOccluderTriangles_; }
 
     /// Return occlusion buffer width.
-    /// @property
     int GetOcclusionBufferSize() const { return occlusionBufferSize_; }
 
     /// Return occluder screen size threshold.
-    /// @property
     float GetOccluderSizeThreshold() const { return occluderSizeThreshold_; }
 
     /// Return whether occlusion rendering is threaded.
-    /// @property
     bool GetThreadedOcclusion() const { return threadedOcclusion_; }
 
     /// Return shadow depth bias multiplier for mobile platforms.
-    /// @property
     float GetMobileShadowBiasMul() const { return mobileShadowBiasMul_; }
 
     /// Return shadow depth bias addition for mobile platforms.
-    /// @property
     float GetMobileShadowBiasAdd() const { return mobileShadowBiasAdd_; }
 
     /// Return shadow normal offset multiplier for mobile platforms.
-    /// @property
     float GetMobileNormalOffsetMul() const { return mobileNormalOffsetMul_; }
 
     /// Return number of views rendered.
-    /// @property
     i32 GetNumViews() const { return views_.Size(); }
 
     /// Return number of primitives rendered.
-    /// @property
     i32 GetNumPrimitives() const { return numPrimitives_; }
 
     /// Return number of batches rendered.
-    /// @property
     i32 GetNumBatches() const { return numBatches_; }
 
     /// Return number of geometries rendered.
-    /// @property
     i32 GetNumGeometries(bool allViews = false) const;
     /// Return number of lights rendered.
-    /// @property
     i32 GetNumLights(bool allViews = false) const;
     /// Return number of shadow maps rendered.
-    /// @property
     i32 GetNumShadowMaps(bool allViews = false) const;
     /// Return number of occluders rendered.
-    /// @property
     i32 GetNumOccluders(bool allViews = false) const;
 
     /// Return the default zone.
-    /// @property
     Zone* GetDefaultZone() const { return defaultZone_; }
 
     /// Return the default material.
-    /// @property
     Material* GetDefaultMaterial() const { return defaultMaterial_; }
 
     /// Return the default range attenuation texture.
-    /// @property
     Texture2D* GetDefaultLightRamp() const { return defaultLightRamp_; }
 
     /// Return the default spotlight attenuation texture.
-    /// @property
     Texture2D* GetDefaultLightSpot() const { return defaultLightSpot_; }
 
     /// Return the shadowed pointlight face selection cube map.

--- a/source/dviglo/graphics/ribbon_trail.h
+++ b/source/dviglo/graphics/ribbon_trail.h
@@ -70,116 +70,86 @@ public:
     UpdateGeometryType GetUpdateGeometryType() override;
 
     /// Set material.
-    /// @property
     void SetMaterial(Material* material);
     /// Set material attribute.
     void SetMaterialAttr(const ResourceRef& value);
     /// Set distance between points.
-    /// @property
     void SetVertexDistance(float length);
     /// Set width of the tail. Only works for face camera trail type.
-    /// @property
     void SetWidth(float width);
     /// Set vertex blended color for start of trail.
-    /// @property
     void SetStartColor(const Color& color);
     /// Set vertex blended color for end of trail.
-    /// @property
     void SetEndColor(const Color& color);
     /// Set vertex blended color for start of trail.
-    /// @property
     void SetStartScale(float startScale);
     /// Set vertex blended scale for end of trail.
-    /// @property
     void SetEndScale(float endScale);
     /// Set how the trail behave.
-    /// @property
     void SetTrailType(TrailType type);
     /// Set base velocity applied to the trail.
-    /// @property
     void SetBaseVelocity(const Vector3& baseVelocity);
     /// Set whether tails are sorted by distance. Default false.
-    /// @property
     void SetSorted(bool enable);
     /// Set tail time to live.
-    /// @property
     void SetLifetime(float time);
     /// Set whether trail should be emitting.
-    /// @property
     void SetEmitting(bool emitting);
     /// Set whether to update when trail emitter are not visible.
-    /// @property
     void SetUpdateInvisible(bool enable);
     /// Set number of column for every tails. Can be useful for fixing distortion at high angle.
-    /// @property
     void SetTailColumn(unsigned tailColumn);
     /// Set animation LOD bias.
-    /// @property
     void SetAnimationLodBias(float bias);
     /// Mark for bounding box and vertex buffer update. Call after modifying the trails.
     void Commit();
 
     /// Return material.
-    /// @property
     Material* GetMaterial() const;
 
     /// Return material attribute.
     ResourceRef GetMaterialAttr() const;
 
     /// Get distance between points.
-    /// @property
     float GetVertexDistance() const { return vertexDistance_;  }
 
     /// Get width of the trail.
-    /// @property
     float GetWidth() const { return width_; }
 
     /// Get vertex blended color for start of trail.
-    /// @property
     const Color& GetStartColor() const { return startColor_; }
 
     /// Get vertex blended color for end of trail.
-    /// @property
     const Color& GetEndColor() const { return endColor_;  }
 
     /// Get vertex blended scale for start of trail.
-    /// @property
     float GetStartScale() const { return startScale_; }
 
     /// Get vertex blended scale for end of trail.
-    /// @property
     float GetEndScale() const { return endScale_; }
 
     /// Return whether tails are sorted.
-    /// @property
     bool IsSorted() const { return sorted_; }
 
     /// Return tail time to live.
-    /// @property
     float GetLifetime() const {return lifetime_;}
 
     /// Return animation LOD bias.
-    /// @property
     float GetAnimationLodBias() const { return animationLodBias_; }
 
     /// Return how the trail behave.
-    /// @property
     TrailType GetTrailType() const { return trailType_; }
 
     /// Return base trail velocity.
-    /// @property
     const Vector3& GetBaseVelocity() const { return baseVelocity_; }
 
     /// Return number of column for tails.
-    /// @property
     unsigned GetTailColumn() const { return tailColumn_; }
 
     /// Return whether is currently emitting.
-    /// @property
     bool IsEmitting() const { return emitting_ ; }
 
     /// Return whether to update when trail emitter are not visible.
-    /// @property
     bool GetUpdateInvisible() const { return updateInvisible_; }
 
 protected:

--- a/source/dviglo/graphics/skeleton.h
+++ b/source/dviglo/graphics/skeleton.h
@@ -109,7 +109,6 @@ public:
     /// Return parent of the given bone. Return null for root bones.
     Bone* GetBoneParent(const Bone* bone);
     /// Return bone by index.
-    /// @property{get_bones}
     Bone* GetBone(i32 index);
     /// Return bone by name.
     Bone* GetBone(const String& name);

--- a/source/dviglo/graphics/skeleton.h
+++ b/source/dviglo/graphics/skeleton.h
@@ -96,11 +96,9 @@ public:
     Vector<Bone>& GetModifiableBones() { return bones_; }
 
     /// Return number of bones.
-    /// @property
     i32 GetNumBones() const { return bones_.Size(); }
 
     /// Return root bone.
-    /// @property
     Bone* GetRootBone();
     /// Return index of the bone by name. Return NINDEX if not found.
     i32 GetBoneIndex(const String& boneName) const;

--- a/source/dviglo/graphics/static_model.h
+++ b/source/dviglo/graphics/static_model.h
@@ -49,34 +49,28 @@ public:
     /// @manualbind
     virtual void SetModel(Model* model);
     /// Set material on all geometries.
-    /// @property
     virtual void SetMaterial(Material* material);
     /// Set material on one geometry. Return true if successful.
     /// @property{set_materials}
     virtual bool SetMaterial(unsigned index, Material* material);
     /// Set occlusion LOD level. By default (NINDEX) same as visible.
-    /// @property
     void SetOcclusionLodLevel(i32 level);
     /// Apply default materials from a material list file. If filename is empty (default), the model's resource name with extension .txt will be used.
     void ApplyMaterialList(const String& fileName = String::EMPTY);
 
     /// Return model.
-    /// @property
     Model* GetModel() const { return model_; }
 
     /// Return number of geometries.
-    /// @property
     unsigned GetNumGeometries() const { return geometries_.Size(); }
 
     /// Return material from the first geometry, assuming all the geometries use the same material.
-    /// @property
     virtual Material* GetMaterial() const { return GetMaterial(0); }
     /// Return material by geometry index.
     /// @property{get_materials}
     virtual Material* GetMaterial(unsigned index) const;
 
     /// Return occlusion LOD level.
-    /// @property
     i32 GetOcclusionLodLevel() const { return occlusionLodLevel_; }
 
     /// Determines if the given world space point is within the model geometry.

--- a/source/dviglo/graphics/static_model.h
+++ b/source/dviglo/graphics/static_model.h
@@ -51,7 +51,6 @@ public:
     /// Set material on all geometries.
     virtual void SetMaterial(Material* material);
     /// Set material on one geometry. Return true if successful.
-    /// @property{set_materials}
     virtual bool SetMaterial(unsigned index, Material* material);
     /// Set occlusion LOD level. By default (NINDEX) same as visible.
     void SetOcclusionLodLevel(i32 level);
@@ -67,7 +66,6 @@ public:
     /// Return material from the first geometry, assuming all the geometries use the same material.
     virtual Material* GetMaterial() const { return GetMaterial(0); }
     /// Return material by geometry index.
-    /// @property{get_materials}
     virtual Material* GetMaterial(unsigned index) const;
 
     /// Return occlusion LOD level.

--- a/source/dviglo/graphics/static_model_group.h
+++ b/source/dviglo/graphics/static_model_group.h
@@ -45,7 +45,6 @@ public:
     unsigned GetNumInstanceNodes() const { return instanceNodes_.Size(); }
 
     /// Return instance node by index.
-    /// @property{get_instanceNodes}
     Node* GetInstanceNode(unsigned index) const;
 
     /// Set node IDs attribute.

--- a/source/dviglo/graphics/static_model_group.h
+++ b/source/dviglo/graphics/static_model_group.h
@@ -42,7 +42,6 @@ public:
     void RemoveAllInstanceNodes();
 
     /// Return number of instance nodes.
-    /// @property
     unsigned GetNumInstanceNodes() const { return instanceNodes_.Size(); }
 
     /// Return instance node by index.

--- a/source/dviglo/graphics/technique.h
+++ b/source/dviglo/graphics/technique.h
@@ -32,43 +32,31 @@ public:
     ~Pass() override;
 
     /// Set blend mode.
-    /// @property
     void SetBlendMode(BlendMode mode);
     /// Set culling mode override. By default culling mode is read from the material instead. Set the illegal culling mode MAX_CULLMODES to disable override again.
-    /// @property
     void SetCullMode(CullMode mode);
     /// Set depth compare mode.
-    /// @property
     void SetDepthTestMode(CompareMode mode);
     /// Set pass lighting mode, affects what shader variations will be attempted to be loaded.
-    /// @property
     void SetLightingMode(PassLightingMode mode);
     /// Set depth write on/off.
-    /// @property
     void SetDepthWrite(bool enable);
     /// Set alpha-to-coverage on/off.
-    /// @property
     void SetAlphaToCoverage(bool enable);
     /// Set whether requires desktop level hardware.
     /// @property{set_desktop}
     void SetIsDesktop(bool enable);
     /// Set vertex shader name.
-    /// @property
     void SetVertexShader(const String& name);
     /// Set pixel shader name.
-    /// @property
     void SetPixelShader(const String& name);
     /// Set vertex shader defines. Separate multiple defines with spaces.
-    /// @property
     void SetVertexShaderDefines(const String& defines);
     /// Set pixel shader defines. Separate multiple defines with spaces.
-    /// @property
     void SetPixelShaderDefines(const String& defines);
     /// Set vertex shader define excludes. Use to mark defines that the shader code will not recognize, to prevent compiling redundant shader variations.
-    /// @property
     void SetVertexShaderDefineExcludes(const String& excludes);
     /// Set pixel shader define excludes. Use to mark defines that the shader code will not recognize, to prevent compiling redundant shader variations.
-    /// @property
     void SetPixelShaderDefineExcludes(const String& excludes);
     /// Reset shader pointers.
     void ReleaseShaders();
@@ -82,58 +70,45 @@ public:
     i32 GetIndex() const { return index_; }
 
     /// Return blend mode.
-    /// @property
     BlendMode GetBlendMode() const { return blendMode_; }
 
     /// Return culling mode override. If pass is not overriding culling mode (default), the illegal mode MAX_CULLMODES is returned.
-    /// @property
     CullMode GetCullMode() const { return cullMode_; }
 
     /// Return depth compare mode.
-    /// @property
     CompareMode GetDepthTestMode() const { return depthTestMode_; }
 
     /// Return pass lighting mode.
-    /// @property
     PassLightingMode GetLightingMode() const { return lightingMode_; }
 
     /// Return last shaders loaded frame number.
     i32 GetShadersLoadedFrameNumber() const { return shadersLoadedFrameNumber_; }
 
     /// Return depth write mode.
-    /// @property
     bool GetDepthWrite() const { return depthWrite_; }
 
     /// Return alpha-to-coverage mode.
-    /// @property
     bool GetAlphaToCoverage() const { return alphaToCoverage_; }
 
     /// Return whether requires desktop level hardware.
-    /// @property
     bool IsDesktop() const { return isDesktop_; }
 
     /// Return vertex shader name.
-    /// @property
     const String& GetVertexShader() const { return vertexShaderName_; }
 
     /// Return pixel shader name.
-    /// @property
     const String& GetPixelShader() const { return pixelShaderName_; }
 
     /// Return vertex shader defines.
-    /// @property
     const String& GetVertexShaderDefines() const { return vertexShaderDefines_; }
 
     /// Return pixel shader defines.
-    /// @property
     const String& GetPixelShaderDefines() const { return pixelShaderDefines_; }
 
     /// Return vertex shader define excludes.
-    /// @property
     const String& GetVertexShaderDefineExcludes() const { return vertexShaderDefineExcludes_; }
 
     /// Return pixel shader define excludes.
-    /// @property
     const String& GetPixelShaderDefineExcludes() const { return pixelShaderDefineExcludes_; }
 
     /// Return vertex shaders.
@@ -226,11 +201,9 @@ public:
     SharedPtr<Technique> Clone(const String& cloneName = String::EMPTY) const;
 
     /// Return whether requires desktop level hardware.
-    /// @property
     bool IsDesktop() const { return isDesktop_; }
 
     /// Return whether technique is supported by the current hardware.
-    /// @property
     bool IsSupported() const { return !isDesktop_ || desktopSupport_; }
 
     /// Return whether has a pass.
@@ -265,13 +238,10 @@ public:
     Pass* GetSupportedPass(const String& name) const;
 
     /// Return number of passes.
-    /// @property
     i32 GetNumPasses() const;
     /// Return all pass names.
-    /// @property
     Vector<String> GetPassNames() const;
     /// Return all passes.
-    /// @property
     Vector<Pass*> GetPasses() const;
 
     /// Return a clone with added shader compilation defines. Called internally by Material.

--- a/source/dviglo/graphics/technique.h
+++ b/source/dviglo/graphics/technique.h
@@ -44,7 +44,6 @@ public:
     /// Set alpha-to-coverage on/off.
     void SetAlphaToCoverage(bool enable);
     /// Set whether requires desktop level hardware.
-    /// @property{set_desktop}
     void SetIsDesktop(bool enable);
     /// Set vertex shader name.
     void SetVertexShader(const String& name);
@@ -189,7 +188,6 @@ public:
     bool BeginLoad(Deserializer& source) override;
 
     /// Set whether requires desktop level hardware.
-    /// @property{set_desktop}
     void SetIsDesktop(bool enable);
     /// Create a new pass.
     Pass* CreatePass(const String& name);

--- a/source/dviglo/graphics/terrain.h
+++ b/source/dviglo/graphics/terrain.h
@@ -110,7 +110,6 @@ public:
     /// Return material.
     Material* GetMaterial() const;
     /// Return patch by index.
-    /// @property{get_patches}
     TerrainPatch* GetPatch(i32 index) const;
     /// Return patch by patch coordinates.
     TerrainPatch* GetPatch(int x, int z) const;

--- a/source/dviglo/graphics/terrain.h
+++ b/source/dviglo/graphics/terrain.h
@@ -36,109 +36,78 @@ public:
     void OnSetEnabled() override;
 
     /// Set patch quads per side. Must be a power of two.
-    /// @property
     void SetPatchSize(int size);
     /// Set vertex (XZ) and height (Y) spacing.
-    /// @property
     void SetSpacing(const Vector3& spacing);
     /// Set maximum number of LOD levels for terrain patches. This can be between 1-4.
-    /// @property
     void SetMaxLodLevels(unsigned levels);
     /// Set LOD level used for terrain patch occlusion. By default (NINDEX) the coarsest. Since the LOD level used needs to be fixed, using finer LOD levels may result in false positive occlusion in cases where the actual rendered geometry is coarser, so use with caution.
-    /// @property
     void SetOcclusionLodLevel(i32 level);
     /// Set smoothing of heightmap.
-    /// @property
     void SetSmoothing(bool enable);
     /// Set heightmap image. Dimensions should be a power of two + 1. Uses 8-bit grayscale, or optionally red as MSB and green as LSB for 16-bit accuracy. Return true if successful.
-    /// @property
     bool SetHeightMap(Image* image);
     /// Set material.
-    /// @property
     void SetMaterial(Material* material);
     /// Set north (positive Z) neighbor terrain for seamless LOD changes across terrains.
-    /// @property
     void SetNorthNeighbor(Terrain* north);
     /// Set south (negative Z) neighbor terrain for seamless LOD changes across terrains.
-    /// @property
     void SetSouthNeighbor(Terrain* south);
     /// Set west (negative X) neighbor terrain for seamless LOD changes across terrains.
-    /// @property
     void SetWestNeighbor(Terrain* west);
     /// Set east (positive X) neighbor terrain for seamless LOD changes across terrains.
-    /// @property
     void SetEastNeighbor(Terrain* east);
     /// Set all neighbor terrains at once.
     void SetNeighbors(Terrain* north, Terrain* south, Terrain* west, Terrain* east);
     /// Set draw distance for patches.
-    /// @property
     void SetDrawDistance(float distance);
     /// Set shadow draw distance for patches.
-    /// @property
     void SetShadowDistance(float distance);
     /// Set LOD bias for patches. Affects which terrain LOD to display.
-    /// @property
     void SetLodBias(float bias);
     /// Set view mask for patches. Is and'ed with camera's view mask to see if the object should be rendered.
-    /// @property
     void SetViewMask(unsigned mask);
     /// Set light mask for patches. Is and'ed with light's and zone's light mask to see if the object should be lit.
-    /// @property
     void SetLightMask(unsigned mask);
     /// Set shadow mask for patches. Is and'ed with light's light mask and zone's shadow mask to see if the object should be rendered to a shadow map.
-    /// @property
     void SetShadowMask(unsigned mask);
     /// Set zone mask for patches. Is and'ed with zone's zone mask to see if the object should belong to the zone.
-    /// @property
     void SetZoneMask(unsigned mask);
     /// Set maximum number of per-pixel lights for patches. Default 0 is unlimited.
-    /// @property
     void SetMaxLights(unsigned num);
     /// Set shadowcaster flag for patches.
-    /// @property
     void SetCastShadows(bool enable);
     /// Set occlusion flag for patches. Occlusion uses the coarsest LOD by default.
-    /// @property
     void SetOccluder(bool enable);
     /// Set occludee flag for patches.
-    /// @property
     void SetOccludee(bool enable);
     /// Apply changes from the heightmap image.
     void ApplyHeightMap();
 
     /// Return patch quads per side.
-    /// @property
     int GetPatchSize() const { return patchSize_; }
 
     /// Return vertex and height spacing.
-    /// @property
     const Vector3& GetSpacing() const { return spacing_; }
 
     /// Return heightmap size in vertices.
-    /// @property
     const IntVector2& GetNumVertices() const { return numVertices_; }
 
     /// Return heightmap size in patches.
-    /// @property
     const IntVector2& GetNumPatches() const { return numPatches_; }
 
     /// Return maximum number of LOD levels for terrain patches. This can be between 1-4.
-    /// @property
     unsigned GetMaxLodLevels() const { return maxLodLevels_; }
 
     /// Return LOD level used for occlusion.
-    /// @property
     i32 GetOcclusionLodLevel() const { return occlusionLodLevel_; }
 
     /// Return whether smoothing is in use.
-    /// @property
     bool GetSmoothing() const { return smoothing_; }
 
     /// Return heightmap image.
-    /// @property
     Image* GetHeightMap() const;
     /// Return material.
-    /// @property
     Material* GetMaterial() const;
     /// Return patch by index.
     /// @property{get_patches}
@@ -157,69 +126,54 @@ public:
     Vector3 HeightMapToWorld(const IntVector2& pixelPosition) const;
 
     /// Return north neighbor terrain.
-    /// @property
     Terrain* GetNorthNeighbor() const { return north_; }
 
     /// Return south neighbor terrain.
-    /// @property
     Terrain* GetSouthNeighbor() const { return south_; }
 
     /// Return west neighbor terrain.
-    /// @property
     Terrain* GetWestNeighbor() const { return west_; }
 
     /// Return east neighbor terrain.
-    /// @property
     Terrain* GetEastNeighbor() const { return east_; }
 
     /// Return raw height data.
     SharedArrayPtr<float> GetHeightData() const { return heightData_; }
 
     /// Return draw distance.
-    /// @property
     float GetDrawDistance() const { return drawDistance_; }
 
     /// Return shadow draw distance.
-    /// @property
     float GetShadowDistance() const { return shadowDistance_; }
 
     /// Return LOD bias.
-    /// @property
     float GetLodBias() const { return lodBias_; }
 
     /// Return view mask.
-    /// @property
     unsigned GetViewMask() const { return viewMask_; }
 
     /// Return light mask.
-    /// @property
     unsigned GetLightMask() const { return lightMask_; }
 
     /// Return shadow mask.
-    /// @property
     unsigned GetShadowMask() const { return shadowMask_; }
 
     /// Return zone mask.
-    /// @property
     unsigned GetZoneMask() const { return zoneMask_; }
 
     /// Return maximum number of per-pixel lights.
-    /// @property
     unsigned GetMaxLights() const { return maxLights_; }
 
     /// Return visible flag.
     bool IsVisible() const { return visible_; }
 
     /// Return shadowcaster flag.
-    /// @property
     bool GetCastShadows() const { return castShadows_; }
 
     /// Return occluder flag.
-    /// @property
     bool IsOccluder() const { return occluder_; }
 
     /// Return occludee flag.
-    /// @property
     bool IsOccludee() const { return occludee_; }
 
     /// Regenerate patch geometry.

--- a/source/dviglo/graphics/viewport.h
+++ b/source/dviglo/graphics/viewport.h
@@ -35,49 +35,37 @@ public:
     ~Viewport() override;
 
     /// Set scene.
-    /// @property
     void SetScene(Scene* scene);
     /// Set viewport camera.
-    /// @property
     void SetCamera(Camera* camera);
     /// Set view rectangle. A zero rectangle (0 0 0 0) means to use the rendertarget's full dimensions.
-    /// @property
     void SetRect(const IntRect& rect);
     /// Set rendering path.
-    /// @property
     void SetRenderPath(RenderPath* renderPath);
     /// Set rendering path from an XML file.
     bool SetRenderPath(XMLFile* file);
     /// Set whether to render debug geometry. Default true.
-    /// @property
     void SetDrawDebug(bool enable);
     /// Set separate camera to use for culling. Sharing a culling camera between several viewports allows to prepare the view only once, saving in CPU use. The culling camera's frustum should cover all the viewport cameras' frusta or else objects may be missing from the rendered view.
-    /// @property
     void SetCullCamera(Camera* camera);
 
     /// Return scene.
-    /// @property
     Scene* GetScene() const;
     /// Return viewport camera.
-    /// @property
     Camera* GetCamera() const;
     /// Return the internal rendering structure. May be null if the viewport has not been rendered yet.
     View* GetView() const;
 
     /// Return view rectangle. A zero rectangle (0 0 0 0) means to use the rendertarget's full dimensions. In this case you could fetch the actual view rectangle from View object, though it will be valid only after the first frame.
-    /// @property
     const IntRect& GetRect() const { return rect_; }
 
     /// Return rendering path.
-    /// @property
     RenderPath* GetRenderPath() const;
 
     /// Return whether to draw debug geometry.
-    /// @property
     bool GetDrawDebug() const { return drawDebug_; }
 
     /// Return the culling camera. If null, the viewport camera will be used for culling (normal case).
-    /// @property
     Camera* GetCullCamera() const;
 
     /// Return ray corresponding to normalized screen coordinates.

--- a/source/dviglo/graphics/zone.h
+++ b/source/dviglo/graphics/zone.h
@@ -29,95 +29,69 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set local-space bounding box. Will be used as an oriented bounding box to test whether objects or the camera are inside.
-    /// @property
     void SetBoundingBox(const BoundingBox& box);
     /// Set ambient color.
-    /// @property
     void SetAmbientColor(const Color& color);
     /// Set fog color.
-    /// @property
     void SetFogColor(const Color& color);
     /// Set fog start distance.
-    /// @property
     void SetFogStart(float start);
     /// Set fog end distance.
-    /// @property
     void SetFogEnd(float end);
     /// Set fog height distance relative to the scene node's world position. Effective only in height fog mode.
-    /// @property
     void SetFogHeight(float height);
     /// Set fog height scale. Effective only in height fog mode.
-    /// @property
     void SetFogHeightScale(float scale);
     /// Set zone priority. If an object or camera is inside several zones, the one with highest priority is used.
-    /// @property
     void SetPriority(int priority);
     /// Set height fog mode.
-    /// @property
     void SetHeightFog(bool enable);
     /// Set override mode. If camera is inside an override zone, that zone will be used for all rendered objects instead of their own zone.
-    /// @property
     void SetOverride(bool enable);
     /// Set ambient gradient mode. In gradient mode ambient color is interpolated from neighbor zones.
-    /// @property
     void SetAmbientGradient(bool enable);
     /// Set zone texture. This will be bound to the zone texture unit when rendering objects inside the zone. Note that the default shaders do not use it.
-    /// @property
     void SetZoneTexture(Texture* texture);
 
     /// Return inverse world transform.
-    /// @property
     const Matrix3x4& GetInverseWorldTransform() const;
 
     /// Return zone's own ambient color, disregarding gradient mode.
-    /// @property
     const Color& GetAmbientColor() const { return ambientColor_; }
 
     /// Return ambient start color. Not safe to call from worker threads due to possible octree query.
-    /// @property
     const Color& GetAmbientStartColor();
     /// Return ambient end color. Not safe to call from worker threads due to possible octree query.
-    /// @property
     const Color& GetAmbientEndColor();
 
     /// Return fog color.
-    /// @property
     const Color& GetFogColor() const { return fogColor_; }
 
     /// Return fog start distance.
-    /// @property
     float GetFogStart() const { return fogStart_; }
 
     /// Return fog end distance.
-    /// @property
     float GetFogEnd() const { return fogEnd_; }
 
     /// Return fog height distance relative to the scene node's world position.
-    /// @property
     float GetFogHeight() const { return fogHeight_; }
 
     /// Return fog height scale.
-    /// @property
     float GetFogHeightScale() const { return fogHeightScale_; }
 
     /// Return zone priority.
-    /// @property
     int GetPriority() const { return priority_; }
 
     /// Return whether height fog mode is enabled.
-    /// @property
     bool GetHeightFog() const { return heightFog_; }
 
     /// Return whether override mode is enabled.
-    /// @property
     bool GetOverride() const { return override_; }
 
     /// Return whether ambient gradient mode is enabled.
-    /// @property
     bool GetAmbientGradient() const { return ambientGradient_; }
 
     /// Return zone texture.
-    /// @property
     Texture* GetZoneTexture() const { return zoneTexture_; }
 
     /// Check whether a point is inside.

--- a/source/dviglo/graphics_api/gpu_object.h
+++ b/source/dviglo/graphics_api/gpu_object.h
@@ -47,7 +47,6 @@ public:
     /// Return the object name. Applicable only on OpenGL.
     u32 GetGPUObjectName() const { return object_.name_; }
     /// Return whether data is lost due to context loss.
-    /// @property
     bool IsDataLost() const { return dataLost_; }
     /// Return whether has pending data assigned while graphics context was lost.
     bool HasPendingData() const { return dataPending_; }

--- a/source/dviglo/graphics_api/index_buffer.h
+++ b/source/dviglo/graphics_api/index_buffer.h
@@ -31,7 +31,6 @@ public:
     void Release() override;
 
     /// Enable shadowing in CPU memory. Shadowing is forced on if the graphics subsystem does not exist.
-    /// @property
     void SetShadowed(bool enable);
     /// Set size and vertex elements and dynamic mode. Previous data will be lost.
     bool SetSize(i32 indexCount, bool largeIndices, bool dynamic = false);
@@ -45,22 +44,18 @@ public:
     void Unlock();
 
     /// Return whether CPU memory shadowing is enabled.
-    /// @property
     bool IsShadowed() const { return shadowed_; }
 
     /// Return whether is dynamic.
-    /// @property
     bool IsDynamic() const { return dynamic_; }
 
     /// Return whether is currently locked.
     bool IsLocked() const { return lockState_ != LOCK_NONE; }
 
     /// Return number of indices.
-    /// @property
     i32 GetIndexCount() const { return indexCount_; }
 
     /// Return index size in bytes.
-    /// @property
     i32 GetIndexSize() const { return indexSize_; }
 
     /// Return used vertex range from index range.

--- a/source/dviglo/graphics_api/render_surface.h
+++ b/source/dviglo/graphics_api/render_surface.h
@@ -26,19 +26,15 @@ public:
     ~RenderSurface() override;
 
     /// Set number of viewports.
-    /// @property
     void SetNumViewports(unsigned num);
     /// Set viewport.
     /// @property{set_viewports}
     void SetViewport(unsigned index, Viewport* viewport);
     /// Set viewport update mode. Default is to update when visible.
-    /// @property
     void SetUpdateMode(RenderSurfaceUpdateMode mode);
     /// Set linked color rendertarget.
-    /// @property
     void SetLinkedRenderTarget(RenderSurface* renderTarget);
     /// Set linked depth-stencil surface.
-    /// @property
     void SetLinkedDepthStencil(RenderSurface* depthStencil);
     /// Queue manual update of the viewport(s).
     void QueueUpdate();
@@ -50,15 +46,12 @@ public:
     bool CreateRenderBuffer(unsigned width, unsigned height, unsigned format, int multiSample);
 
     /// Return width.
-    /// @property
     int GetWidth() const;
 
     /// Return height.
-    /// @property
     int GetHeight() const;
 
     /// Return usage.
-    /// @property
     TextureUsage GetUsage() const;
 
     /// Return multisampling level.
@@ -68,7 +61,6 @@ public:
     bool GetAutoResolve() const;
 
     /// Return number of viewports.
-    /// @property
     unsigned GetNumViewports() const { return viewports_.Size(); }
 
     /// Return viewport by index.
@@ -76,15 +68,12 @@ public:
     Viewport* GetViewport(unsigned index) const;
 
     /// Return viewport update mode.
-    /// @property
     RenderSurfaceUpdateMode GetUpdateMode() const { return updateMode_; }
 
     /// Return linked color rendertarget.
-    /// @property
     RenderSurface* GetLinkedRenderTarget() const { return linkedRenderTarget_; }
 
     /// Return linked depth-stencil surface.
-    /// @property
     RenderSurface* GetLinkedDepthStencil() const { return linkedDepthStencil_; }
 
     /// Return whether manual update queued. Called internally.
@@ -94,7 +83,6 @@ public:
     void ResetUpdateQueued();
 
     /// Return parent texture.
-    /// @property
     Texture* GetParentTexture() const { return parentTexture_; }
 
     /// Return Direct3D9 surface.
@@ -113,7 +101,6 @@ public:
     unsigned GetRenderBuffer() const { return renderBuffer_; }
 
     /// Return whether multisampled rendertarget needs resolve.
-    /// @property
     bool IsResolveDirty() const { return resolveDirty_; }
 
     /// Set or clear the need resolve flag. Called internally by Graphics.

--- a/source/dviglo/graphics_api/render_surface.h
+++ b/source/dviglo/graphics_api/render_surface.h
@@ -28,7 +28,6 @@ public:
     /// Set number of viewports.
     void SetNumViewports(unsigned num);
     /// Set viewport.
-    /// @property{set_viewports}
     void SetViewport(unsigned index, Viewport* viewport);
     /// Set viewport update mode. Default is to update when visible.
     void SetUpdateMode(RenderSurfaceUpdateMode mode);
@@ -64,7 +63,6 @@ public:
     unsigned GetNumViewports() const { return viewports_.Size(); }
 
     /// Return viewport by index.
-    /// @property{get_viewports}
     Viewport* GetViewport(unsigned index) const;
 
     /// Return viewport update mode.

--- a/source/dviglo/graphics_api/texture.h
+++ b/source/dviglo/graphics_api/texture.h
@@ -35,109 +35,83 @@ public:
      */
     void SetNumLevels(unsigned levels);
     /// Set filtering mode.
-    /// @property
     void SetFilterMode(TextureFilterMode mode);
     /// Set addressing mode by texture coordinate.
-    /// @property
     void SetAddressMode(TextureCoordinate coord, TextureAddressMode mode);
     /// Set texture max. anisotropy level. No effect if not using anisotropic filtering. Value 0 (default) uses the default setting from Renderer.
-    /// @property
     void SetAnisotropy(unsigned level);
     /// Set shadow compare mode. Not used on Direct3D9.
     void SetShadowCompare(bool enable);
     /// Set border color for border addressing mode.
-    /// @property
     void SetBorderColor(const Color& color);
     /// Set sRGB sampling and writing mode.
-    /// @property
     void SetSRGB(bool enable);
     /// Set backup texture to use when rendering to this texture.
-    /// @property
     void SetBackupTexture(Texture* texture);
     /// Set mip levels to skip on a quality setting when loading. Ensures higher quality levels do not skip more.
-    /// @property
     void SetMipsToSkip(MaterialQuality quality, int toSkip);
 
     /// Return API-specific texture format.
-    /// @property
     unsigned GetFormat() const { return format_; }
 
     /// Return whether the texture format is compressed.
-    /// @property
     bool IsCompressed() const;
 
     /// Return number of mip levels.
-    /// @property
     unsigned GetLevels() const { return levels_; }
 
     /// Return width.
-    /// @property
     int GetWidth() const { return width_; }
 
     /// Return height.
-    /// @property
     int GetHeight() const { return height_; }
 
     /// Return depth.
     int GetDepth() const { return depth_; }
 
     /// Return filtering mode.
-    /// @property
     TextureFilterMode GetFilterMode() const { return filterMode_; }
 
     /// Return addressing mode by texture coordinate.
-    /// @property
     TextureAddressMode GetAddressMode(TextureCoordinate coord) const { return addressModes_[coord]; }
 
     /// Return texture max. anisotropy level. Value 0 means to use the default value from Renderer.
-    /// @property
     unsigned GetAnisotropy() const { return anisotropy_; }
 
     /// Return whether shadow compare is enabled. Not used on Direct3D9.
     bool GetShadowCompare() const { return shadowCompare_; }
 
     /// Return border color.
-    /// @property
     const Color& GetBorderColor() const { return borderColor_; }
 
     /// Return whether is using sRGB sampling and writing.
-    /// @property
     bool GetSRGB() const { return sRGB_; }
 
     /// Return texture multisampling level (1 = no multisampling).
-    /// @property
     int GetMultiSample() const { return multiSample_; }
 
     /// Return texture multisampling autoresolve mode. When true, the texture is resolved before being sampled on SetTexture(). When false, the texture will not be resolved and must be read as individual samples in the shader.
-    /// @property
     bool GetAutoResolve() const { return autoResolve_; }
 
     /// Return whether multisampled texture needs resolve.
-    /// @property
     bool IsResolveDirty() const { return resolveDirty_; }
 
     /// Return whether rendertarget mipmap levels need regenration.
-    /// @property
     bool GetLevelsDirty() const { return levelsDirty_; }
 
     /// Return backup texture.
-    /// @property
     Texture* GetBackupTexture() const { return backupTexture_; }
 
     /// Return mip levels to skip on a quality setting when loading.
-    /// @property
     int GetMipsToSkip(MaterialQuality quality) const;
     /// Return mip level width, or 0 if level does not exist.
-    /// @property
     int GetLevelWidth(unsigned level) const;
     /// Return mip level width, or 0 if level does not exist.
-    /// @property
     int GetLevelHeight(unsigned level) const;
     /// Return mip level depth, or 0 if level does not exist.
     int GetLevelDepth(unsigned level) const;
 
     /// Return texture usage type.
-    /// @property
     TextureUsage GetUsage() const { return usage_; }
 
     /// Return data size in bytes for a rectangular region.
@@ -147,7 +121,6 @@ public:
     /// Return data size in bytes for a pixel or block row.
     unsigned GetRowDataSize(int width) const;
     /// Return number of image components required to receive pixel data from GetData(), or 0 for compressed images.
-    /// @property
     unsigned GetComponents() const;
 
     /// Return whether the parameters are dirty.

--- a/source/dviglo/graphics_api/texture_2d.h
+++ b/source/dviglo/graphics_api/texture_2d.h
@@ -57,7 +57,6 @@ public:
     SharedPtr<Image> GetImage() const;
 
     /// Return render surface.
-    /// @property
     RenderSurface* GetRenderSurface() const { return renderSurface_; }
 
 protected:

--- a/source/dviglo/graphics_api/texture_2d_array.h
+++ b/source/dviglo/graphics_api/texture_2d_array.h
@@ -40,7 +40,6 @@ public:
     void Release() override;
 
     /// Set the number of layers in the texture. To be used before SetData.
-    /// @property
     void SetLayers(unsigned layers);
     /// Set layers, size, format and usage. Set layers to zero to leave them unchanged. Return true if successful.
     bool SetSize(unsigned layers, int width, int height, unsigned format, TextureUsage usage = TEXTURE_STATIC);
@@ -52,12 +51,10 @@ public:
     bool SetData(unsigned layer, Image* image, bool useAlpha = false);
 
     /// Return number of layers in the texture.
-    /// @property
     unsigned GetLayers() const { return layers_; }
     /// Get data from a mip level. The destination buffer must be big enough. Return true if successful.
     bool GetData(unsigned layer, unsigned level, void* dest) const;
     /// Return render surface.
-    /// @property
     RenderSurface* GetRenderSurface() const { return renderSurface_; }
 
 protected:

--- a/source/dviglo/graphics_api/texture_cube.h
+++ b/source/dviglo/graphics_api/texture_cube.h
@@ -54,7 +54,6 @@ public:
     SharedPtr<Image> GetImage(CubeMapFace face) const;
 
     /// Return render surface for one face.
-    /// @property{get_renderSurfaces}
     RenderSurface* GetRenderSurface(CubeMapFace face) const { return renderSurfaces_[face]; }
 
 protected:

--- a/source/dviglo/graphics_api/vertex_buffer.h
+++ b/source/dviglo/graphics_api/vertex_buffer.h
@@ -31,7 +31,6 @@ public:
     void Release() override;
 
     /// Enable shadowing in CPU memory. Shadowing is forced on if the graphics subsystem does not exist.
-    /// @property
     void SetShadowed(bool enable);
     /// Set size, vertex elements and dynamic mode. Previous data will be lost.
     bool SetSize(i32 vertexCount, const Vector<VertexElement>& elements, bool dynamic = false);
@@ -47,26 +46,21 @@ public:
     void Unlock();
 
     /// Return whether CPU memory shadowing is enabled.
-    /// @property
     bool IsShadowed() const { return shadowed_; }
 
     /// Return whether is dynamic.
-    /// @property
     bool IsDynamic() const { return dynamic_; }
 
     /// Return whether is currently locked.
     bool IsLocked() const { return lockState_ != LOCK_NONE; }
 
     /// Return number of vertices.
-    /// @property
     i32 GetVertexCount() const { return vertexCount_; }
 
     /// Return vertex size in bytes.
-    /// @property
     i32 GetVertexSize() const { return vertexSize_; }
 
     /// Return vertex elements.
-    /// @property
     const Vector<VertexElement>& GetElements() const { return elements_; }
 
     /// Return vertex element, or null if does not exist.
@@ -106,7 +100,6 @@ public:
     }
 
     /// Return legacy vertex element mask. Note that both semantic and type must match the legacy element for a mask bit to be set.
-    /// @property
     VertexElements GetElementMask() const { return elementMask_; }
 
     /// Return CPU memory shadow data.

--- a/source/dviglo/ik/ik_effector.h
+++ b/source/dviglo/ik/ik_effector.h
@@ -64,7 +64,6 @@ public:
     Node* GetTargetNode() const;
 
     /*!
-     * @property
      * @brief The position of the target node provides the target position of
      * the effector node.
      *
@@ -79,14 +78,12 @@ public:
     void SetTargetNode(Node* targetNode);
 
     /*!
-     * @property
      * @brief Retrieves the name of the target node. The node doesn't
      * necessarily have to exist in the scene graph.
      */
     const String& GetTargetName() const;
 
     /*!
-     * @property
      * @brief Sets the name of the target node. The node doesn't necessarily
      * have to exist in the scene graph. When a node is created that matches
      * this name, it is selected as the target.
@@ -118,7 +115,6 @@ public:
     float GetWeight() const;
 
     /*!
-     * @property
      * @brief Sets how much influence the effector has on the solution.
      *
      * You can use this value to smoothly transition between a solved pose and
@@ -131,7 +127,6 @@ public:
     float GetRotationWeight() const;
 
     /*!
-     * @property
      * @brief Sets how much influence the target rotation should have on the
      * solution. A value of 1 means to match the target rotation exactly, if
      * possible. A value of 0 means to not match it at all.
@@ -144,7 +139,6 @@ public:
     float GetRotationDecay() const;
 
     /*!
-     * @property
      * @brief A factor with which to control the target rotation influence of
      * the next segments down the chain.
      *

--- a/source/dviglo/ik/ik_effector.h
+++ b/source/dviglo/ik/ik_effector.h
@@ -61,7 +61,6 @@ public:
     void SetFeature(Feature feature, bool enable);
 
     /// Retrieves the node that is being used as a target. Can be NULL.
-    /// @property
     Node* GetTargetNode() const;
 
     /*!
@@ -96,17 +95,13 @@ public:
     void SetTargetName(const String& nodeName);
 
     /// Returns the current target position in world space.
-    /// @property
     const Vector3& GetTargetPosition() const;
     /// Sets the current target position. If the effector has a target node then this will have no effect.
-    /// @property
     void SetTargetPosition(const Vector3& targetPosition);
 
     /// Gets the current target rotation in world space.
-    /// @property
     const Quaternion& GetTargetRotation() const;
     /// Sets the current target rotation. If the effector has a target node then this will have no effect.
-    /// @property
     void SetTargetRotation(const Quaternion& targetRotation);
 
     /// Required for the editor, get the target rotation in euler angles.
@@ -115,14 +110,11 @@ public:
     void SetTargetRotationEuler(const Vector3& targetRotation);
 
     /// Returns the number of segments that will be affected by this effector. 0 Means all nodes between this effector and the next IKSolver.
-    /// @property
     unsigned GetChainLength() const;
     /// Sets the number of segments that will be affected. 0 Means all nodes between this effector and the next IKSolver.
-    /// @property
     void SetChainLength(unsigned chainLength);
 
     /// How strongly the effector affects the solution.
-    /// @property
     float GetWeight() const;
 
     /*!
@@ -136,7 +128,6 @@ public:
     void SetWeight(float weight);
 
     /// How strongly the target node's rotation influences the solution.
-    /// @property
     float GetRotationWeight() const;
 
     /*!
@@ -150,7 +141,6 @@ public:
     void SetRotationWeight(float weight);
 
     /// Retrieves the rotation decay factor. See SetRotationDecay() for info.
-    /// @property
     float GetRotationDecay() const;
 
     /*!

--- a/source/dviglo/ik/ik_solver.h
+++ b/source/dviglo/ik/ik_solver.h
@@ -339,34 +339,20 @@ private:
 
     // Need these wrapper functions flags of GetFeature/SetFeature can be correctly exposed to the editor and to AngelScript and lua
 public:
-    /// @property{get_JOINT_ROTATIONS}
     bool GetJOINT_ROTATIONS() const;
-    /// @property{get_TARGET_ROTATIONS}
     bool GetTARGET_ROTATIONS() const;
-    /// @property{get_UPDATE_ORIGINAL_POSE}
     bool GetUPDATE_ORIGINAL_POSE() const;
-    /// @property{get_UPDATE_ACTIVE_POSE(}
     bool GetUPDATE_ACTIVE_POSE() const;
-    /// @property{get_USE_ORIGINAL_POSE}
     bool GetUSE_ORIGINAL_POSE() const;
-    /// @property{get_CONSTRAINTS}
     bool GetCONSTRAINTS() const;
-    /// @property{get_AUTO_SOLVE}
     bool GetAUTO_SOLVE() const;
 
-    /// @property{set_JOINT_ROTATIONS}
     void SetJOINT_ROTATIONS(bool enable);
-    /// @property{set_TARGET_ROTATIONS}
     void SetTARGET_ROTATIONS(bool enable);
-    /// @property{set_UPDATE_ORIGINAL_POSE}
     void SetUPDATE_ORIGINAL_POSE(bool enable);
-    /// @property{set_UPDATE_ACTIVE_POSE}
     void SetUPDATE_ACTIVE_POSE(bool enable);
-    /// @property{set_USE_ORIGINAL_POSE}
     void SetUSE_ORIGINAL_POSE(bool enable);
-    /// @property{set_CONSTRAINTS}
     void SetCONSTRAINTS(bool enable);
-    /// @property{set_AUTO_SOLVE}
     void SetAUTO_SOLVE(bool enable);
 
 private:

--- a/source/dviglo/ik/ik_solver.h
+++ b/source/dviglo/ik/ik_solver.h
@@ -188,7 +188,6 @@ public:
     unsigned GetMaximumIterations() const;
 
     /*!
-     * @property
      * @brief Sets the maximum number of iterations the solver is allowed to
      * perform before applying the result.
      *
@@ -211,7 +210,6 @@ public:
     float GetTolerance() const;
 
     /*!
-     * @property
      * @brief Sets the distance at which the effector is "close enough" to the
      * target node, at which point the algorithm will stop iterating.
      *

--- a/source/dviglo/ik/ik_solver.h
+++ b/source/dviglo/ik/ik_solver.h
@@ -185,7 +185,6 @@ public:
     void SetFeature(Feature feature, bool enable);
 
     /// Returns the configured maximum number of iterations.
-    /// @property
     unsigned GetMaximumIterations() const;
 
     /*!
@@ -209,7 +208,6 @@ public:
     void SetMaximumIterations(unsigned iterations);
 
     /// Returns the configured tolerance.
-    /// @property
     float GetTolerance() const;
 
     /*!

--- a/source/dviglo/input/input.h
+++ b/source/dviglo/input/input.h
@@ -40,7 +40,6 @@ inline const IntVector2 MOUSE_POSITION_OFFSCREEN = IntVector2(M_MIN_INT, M_MIN_I
 struct TouchState
 {
     /// Return last touched UI element, used by scripting integration.
-    /// @property
     UIElement* GetTouchedElement();
 
     /// Touch (finger) ID.
@@ -68,23 +67,18 @@ struct JoystickState
     void Reset();
 
     /// Return whether is a gamepad. Gamepads will use standardized axis and button mappings.
-    /// @property
     bool IsGamepad() const { return gamepad_ != nullptr; }
 
     /// Return number of buttons.
-    /// @property
     i32 GetNumButtons() const { return buttons_.Size(); }
 
     /// Return number of axes.
-    /// @property
     i32 GetNumAxes() const { return axes_.Size(); }
 
     /// Return number of hats.
-    /// @property
     i32 GetNumHats() const { return hats_.Size(); }
 
     /// Check if a button is held down.
-    /// @property
     bool GetButtonDown(i32 index) const
     {
         assert(index >= 0);
@@ -92,7 +86,6 @@ struct JoystickState
     }
 
     /// Check if a button has been pressed on this frame.
-    /// @property
     bool GetButtonPress(i32 index) const
     {
         assert(index >= 0);
@@ -100,7 +93,6 @@ struct JoystickState
     }
 
     /// Return axis position.
-    /// @property
     float GetAxisPosition(i32 index) const
     {
         assert(index >= 0);
@@ -108,7 +100,6 @@ struct JoystickState
     }
 
     /// Return hat position.
-    /// @property
     int GetHatPosition(i32 index) const
     {
         assert(index >= 0);
@@ -157,7 +148,6 @@ public:
     /// Poll for window messages. Called by HandleBeginFrame().
     void Update();
     /// Set whether ALT-ENTER fullscreen toggle is enabled.
-    /// @property
     void SetToggleFullscreen(bool enable);
     /// Set whether the operating system mouse cursor is visible. When not visible (default), is kept centered to prevent leaving the window. Mouse visibility event can be suppressed-- this also recalls any unsuppressed SetMouseVisible which can be returned by ResetMouseVisible().
     void SetMouseVisible(bool enable, bool suppressEvent = false);
@@ -203,13 +193,10 @@ public:
      */
     bool RemoveScreenJoystick(SDL_JoystickID id);
     /// Set whether the virtual joystick is visible.
-    /// @property
     void SetScreenJoystickVisible(SDL_JoystickID id, bool enable);
     /// Show or hide on-screen keyboard on platforms that support it. When shown, keypresses from it are delivered as key events.
-    /// @property
     void SetScreenKeyboardVisible(bool enable);
     /// Set touch emulation by mouse. Only available on desktop platforms. When enabled, actual mouse events are no longer sent and the mouse cursor is forced visible.
-    /// @property
     void SetTouchEmulation(bool enable);
     /// Begin recording a touch gesture. Return true if successful. The E_GESTURERECORDED event (which contains the ID for the new gesture) will be sent when recording finishes.
     bool RecordGesture();
@@ -224,7 +211,6 @@ public:
     /// Remove all in-memory gestures.
     void RemoveAllGestures();
     /// Set the mouse cursor position. Uses the backbuffer (Graphics width/height) coordinates.
-    /// @property
     void SetMousePosition(const IntVector2& position);
     /// Center the mouse position.
     void CenterMousePosition();
@@ -242,60 +228,43 @@ public:
     /// Return name of key from scancode.
     String GetScancodeName(Scancode scancode) const;
     /// Check if a key is held down.
-    /// @property
     bool GetKeyDown(Key key) const;
     /// Check if a key has been pressed on this frame.
-    /// @property
     bool GetKeyPress(Key key) const;
     /// Check if a key is held down by scancode.
-    /// @property
     bool GetScancodeDown(Scancode scancode) const;
     /// Check if a key has been pressed on this frame by scancode.
-    /// @property
     bool GetScancodePress(Scancode scancode) const;
     /// Check if a mouse button is held down.
-    /// @property
     bool GetMouseButtonDown(MouseButtonFlags button) const;
     /// Check if a mouse button has been pressed on this frame.
-    /// @property
     bool GetMouseButtonPress(MouseButtonFlags button) const;
     /// Check if a qualifier key is held down.
-    /// @property
     bool GetQualifierDown(Qualifier qualifier) const;
     /// Check if a qualifier key has been pressed on this frame.
-    /// @property
     bool GetQualifierPress(Qualifier qualifier) const;
     /// Return the currently held down qualifiers.
-    /// @property
     QualifierFlags GetQualifiers() const;
     /// Return mouse position within window. Should only be used with a visible mouse cursor. Uses the backbuffer (Graphics width/height) coordinates.
-    /// @property
     IntVector2 GetMousePosition() const;
     /// Return mouse movement since last frame.
-    /// @property
     IntVector2 GetMouseMove() const;
     /// Return horizontal mouse movement since last frame.
-    /// @property
     int GetMouseMoveX() const;
     /// Return vertical mouse movement since last frame.
-    /// @property
     int GetMouseMoveY() const;
     /// Return mouse wheel movement since last frame.
-    /// @property
     int GetMouseMoveWheel() const { return mouseMoveWheel_; }
     /// Return input coordinate scaling. Should return non-unity on High DPI display.
-    /// @property
     Vector2 GetInputScale() const { return inputScale_; }
 
     /// Return number of active finger touches.
-    /// @property
     i32 GetNumTouches() const { return touches_.Size(); }
     /// Return active finger touch by index.
     /// @property{get_touches}
     TouchState* GetTouch(i32 index) const;
 
     /// Return number of connected joysticks.
-    /// @property
     i32 GetNumJoysticks() const { return joysticks_.Size(); }
     /// Return joystick state by ID, or null if does not exist.
     /// @property{get_joysticks}
@@ -308,35 +277,26 @@ public:
     JoystickState* GetJoystickByName(const String& name);
 
     /// Return whether fullscreen toggle is enabled.
-    /// @property
     bool GetToggleFullscreen() const { return toggleFullscreen_; }
 
     /// Return whether a virtual joystick is visible.
-    /// @property
     bool IsScreenJoystickVisible(SDL_JoystickID id) const;
     /// Return whether on-screen keyboard is supported.
-    /// @property
     bool GetScreenKeyboardSupport() const;
     /// Return whether on-screen keyboard is being shown.
-    /// @property
     bool IsScreenKeyboardVisible() const;
 
     /// Return whether touch emulation is enabled.
-    /// @property
     bool GetTouchEmulation() const { return touchEmulation_; }
 
     /// Return whether the operating system mouse cursor is visible.
-    /// @property
     bool IsMouseVisible() const { return mouseVisible_; }
     /// Return whether the mouse is currently being grabbed by an operation.
-    /// @property
     bool IsMouseGrabbed() const { return mouseGrabbed_; }
     /// Return whether the mouse is locked to the window.
-    /// @property
     bool IsMouseLocked() const;
 
     /// Return the mouse mode.
-    /// @property
     MouseMode GetMouseMode() const { return mouseMode_; }
 
     /// Return whether application window has input focus.
@@ -344,7 +304,6 @@ public:
     bool HasFocus() { return inputFocus_; }
 
     /// Return whether application window is minimized.
-    /// @property
     bool IsMinimized() const;
 
 private:

--- a/source/dviglo/input/input.h
+++ b/source/dviglo/input/input.h
@@ -261,19 +261,15 @@ public:
     /// Return number of active finger touches.
     i32 GetNumTouches() const { return touches_.Size(); }
     /// Return active finger touch by index.
-    /// @property{get_touches}
     TouchState* GetTouch(i32 index) const;
 
     /// Return number of connected joysticks.
     i32 GetNumJoysticks() const { return joysticks_.Size(); }
     /// Return joystick state by ID, or null if does not exist.
-    /// @property{get_joysticks}
     JoystickState* GetJoystick(SDL_JoystickID id);
     /// Return joystick state by index, or null if does not exist. 0 = first connected joystick.
-    /// @property{get_joysticksByIndex}
     JoystickState* GetJoystickByIndex(i32 index);
     /// Return joystick state by name, or null if does not exist.
-    /// @property{get_joysticksByName}
     JoystickState* GetJoystickByName(const String& name);
 
     /// Return whether fullscreen toggle is enabled.
@@ -300,7 +296,6 @@ public:
     MouseMode GetMouseMode() const { return mouseMode_; }
 
     /// Return whether application window has input focus.
-    /// @property{get_focus}
     bool HasFocus() { return inputFocus_; }
 
     /// Return whether application window is minimized.

--- a/source/dviglo/io/abstract_file.h
+++ b/source/dviglo/io/abstract_file.h
@@ -21,7 +21,6 @@ public:
     /// Destruct.
     ~AbstractFile() override = default;
     /// Change the file name. Used by the resource system.
-    /// @property
     virtual void SetName(const String& name) { name_ = name; }
     /// Return the file name.
     const String& GetName() const override { return name_; }

--- a/source/dviglo/io/deserializer.h
+++ b/source/dviglo/io/deserializer.h
@@ -28,25 +28,20 @@ public:
     /// Set position from the beginning of the stream. Return actual new position.
     virtual i64 Seek(i64 position) = 0;
     /// Return name of the stream.
-    /// @property
     virtual const String& GetName() const;
     /// Return a checksum if applicable.
-    /// @property
     virtual hash32 GetChecksum();
     /// Return whether the end of stream has been reached.
-    /// @property
     virtual bool IsEof() const { return position_ >= size_; }
 
     /// Set position relative to current position. Return actual new position.
     i64 SeekRelative(i64 delta);
     /// Return current position.
-    /// @property
     i64 GetPosition() const { return position_; }
     /// Return current position.
     i64 Tell() const { return position_; }
 
     /// Return size.
-    /// @property
     i64 GetSize() const { return size_; }
 
     /// Read a 64-bit integer.

--- a/source/dviglo/io/file.h
+++ b/source/dviglo/io/file.h
@@ -75,18 +75,15 @@ public:
     void Flush();
 
     /// Return the open mode.
-    /// @property
     FileMode GetMode() const { return mode_; }
 
     /// Return whether is open.
-    /// @property
     bool IsOpen() const;
 
     /// Return the file handle.
     void* GetHandle() const { return handle_; }
 
     /// Return whether the file originates from a package.
-    /// @property
     bool IsPackaged() const { return offset_ != 0; }
 
 private:

--- a/source/dviglo/io/file_system.h
+++ b/source/dviglo/io/file_system.h
@@ -32,12 +32,10 @@ public:
     ~FileSystem() override;
 
     /// Set the current working directory.
-    /// @property
     bool SetCurrentDir(const String& pathName);
     /// Create a directory.
     bool CreateDir(const String& pathName);
     /// Set whether to execute engine console commands as OS-specific system command.
-    /// @property
     void SetExecuteConsoleCommands(bool enable);
     /// Run a program using the command interpreter, block until it exits and return the exit code. Will fail if any allowed paths are defined.
     int SystemCommand(const String& commandLine, bool redirectStdOutToLog = false);
@@ -61,11 +59,9 @@ public:
     bool SetLastModifiedTime(const String& fileName, unsigned newTime);
 
     /// Return the absolute current working directory.
-    /// @property
     String GetCurrentDir() const;
 
     /// Return whether is executing engine console commands as OS-specific system command.
-    /// @property
     bool GetExecuteConsoleCommands() const { return executeConsoleCommands_; }
 
     /// Return whether paths have been registered.
@@ -82,15 +78,12 @@ public:
     /// Scan a directory for specified files.
     void ScanDir(Vector<String>& result, const String& pathName, const String& filter, unsigned flags, bool recursive) const;
     /// Return the program's directory.
-    /// @property
     String GetProgramDir() const;
     /// Return the user documents directory.
-    /// @property
     String GetUserDocumentsDir() const;
     /// Return the application preferences directory.
     String GetAppPreferencesDir(const String& org, const String& app) const;
     /// Return path of temporary directory. Path always ends with a forward slash.
-    /// @property
     String GetTemporaryDir() const;
 
 private:

--- a/source/dviglo/io/log.h
+++ b/source/dviglo/io/log.h
@@ -67,29 +67,22 @@ public:
     /// Close the log file.
     void Close();
     /// Set logging level.
-    /// @property
     void SetLevel(int level);
     /// Set whether to timestamp log messages.
-    /// @property
     void SetTimeStamp(bool enable);
     /// Set quiet mode ie. only print error entries to standard error stream (which is normally redirected to console also). Output to log file is not affected by this mode.
-    /// @property
     void SetQuiet(bool quiet);
 
     /// Return logging level.
-    /// @property
     int GetLevel() const { return level_; }
 
     /// Return whether log messages are timestamped.
-    /// @property
     bool GetTimeStamp() const { return timeStamp_; }
 
     /// Return last log message.
-    /// @property
     String GetLastMessage() const { return lastMessage_; }
 
     /// Return whether log is in quiet mode (only errors printed to standard error stream).
-    /// @property
     bool IsQuiet() const { return quiet_; }
 
     /// Write to the log. If logging level is higher than the level of the message, the message is ignored.

--- a/source/dviglo/io/named_pipe.h
+++ b/source/dviglo/io/named_pipe.h
@@ -45,10 +45,8 @@ public:
     void Close();
 
     /// Return whether is open.
-    /// @property
     bool IsOpen() const;
     /// Return whether is in server mode.
-    /// @property
     bool IsServer() const { return isServer_; }
 
 private:

--- a/source/dviglo/io/package_file.h
+++ b/source/dviglo/io/package_file.h
@@ -46,30 +46,24 @@ public:
     const HashMap<String, PackageEntry>& GetEntries() const { return entries_; }
 
     /// Return the package file name.
-    /// @property
     const String& GetName() const { return fileName_; }
 
     /// Return hash of the package file name.
     StringHash GetNameHash() const { return nameHash_; }
 
     /// Return number of files.
-    /// @property
     unsigned GetNumFiles() const { return entries_.Size(); }
 
     /// Return total size of the package file.
-    /// @property
     unsigned GetTotalSize() const { return totalSize_; }
 
     /// Return total data size from all the file entries in the package file.
-    /// @property
     unsigned GetTotalDataSize() const { return totalDataSize_; }
 
     /// Return checksum of the package file contents.
-    /// @property
     hash32 GetChecksum() const { return checksum_; }
 
     /// Return whether the files are compressed.
-    /// @property
     bool IsCompressed() const { return compressed_; }
 
     /// Return list of file names in the package.

--- a/source/dviglo/math/bounding_box.h
+++ b/source/dviglo/math/bounding_box.h
@@ -243,15 +243,12 @@ public:
     }
 
     /// Return center.
-    /// @property
     Vector3 Center() const { return (max_ + min_) * 0.5f; }
 
     /// Return size.
-    /// @property
     Vector3 Size() const { return max_ - min_; }
 
     /// Return half-size.
-    /// @property
     Vector3 HalfSize() const { return (max_ - min_) * 0.5f; }
 
     /// Return transformed by a 3x3 matrix.

--- a/source/dviglo/math/color.h
+++ b/source/dviglo/math/color.h
@@ -143,11 +143,9 @@ public:
     void FromHSV(float h, float s, float v, float a = 1.0f);
 
     /// Return RGB as a three-dimensional vector.
-    /// @property{get_rgb}
     Vector3 ToVector3() const { return Vector3(r_, g_, b_); }
 
     /// Return RGBA as a four-dimensional vector.
-    /// @property{get_rgba}
     Vector4 ToVector4() const { return Vector4(r_, g_, b_, a_); }
 
     /// Return sum of RGB components.

--- a/source/dviglo/math/plane.h
+++ b/source/dviglo/math/plane.h
@@ -86,7 +86,6 @@ public:
     Vector3 Reflect(const Vector3& direction) const { return direction - (2.0f * normal_.DotProduct(direction) * normal_); }
 
     /// Return a reflection matrix.
-    /// @property
     Matrix3x4 ReflectionMatrix() const;
     /// Return transformed by a 3x3 matrix.
     Plane Transformed(const Matrix3& transform) const;

--- a/source/dviglo/math/quaternion.h
+++ b/source/dviglo/math/quaternion.h
@@ -427,13 +427,10 @@ public:
     /// Return Euler angles in degrees.
     Vector3 EulerAngles() const;
     /// Return yaw angle in degrees.
-    /// @property{get_yaw}
     float YawAngle() const;
     /// Return pitch angle in degrees.
-    /// @property{get_pitch}
     float PitchAngle() const;
     /// Return roll angle in degrees.
-    /// @property{get_roll}
     float RollAngle() const;
     /// Return rotation axis.
     Vector3 Axis() const;

--- a/source/dviglo/math/quaternion.h
+++ b/source/dviglo/math/quaternion.h
@@ -425,7 +425,6 @@ public:
     }
 
     /// Return Euler angles in degrees.
-    /// @property
     Vector3 EulerAngles() const;
     /// Return yaw angle in degrees.
     /// @property{get_yaw}
@@ -437,13 +436,10 @@ public:
     /// @property{get_roll}
     float RollAngle() const;
     /// Return rotation axis.
-    /// @property
     Vector3 Axis() const;
     /// Return rotation angle.
-    /// @property
     float Angle() const;
     /// Return the rotation matrix that corresponds to this quaternion.
-    /// @property
     Matrix3 RotationMatrix() const;
     /// Spherical interpolation with another quaternion.
     Quaternion Slerp(const Quaternion& rhs, float t) const;

--- a/source/dviglo/math/rect.h
+++ b/source/dviglo/math/rect.h
@@ -180,15 +180,12 @@ public:
     }
 
     /// Return center.
-    /// @property
     Vector2 Center() const { return (max_ + min_) * 0.5f; }
 
     /// Return size.
-    /// @property
     Vector2 Size() const { return max_ - min_; }
 
     /// Return half-size.
-    /// @property
     Vector2 HalfSize() const { return (max_ - min_) * 0.5f; }
 
     /// Test for equality with another rect with epsilon.
@@ -230,19 +227,15 @@ public:
     Vector2 Max() const { return max_; }
 
     /// Return left coordinate.
-    /// @property
     float Left() const { return min_.x_; }
 
     /// Return top coordinate.
-    /// @property
     float Top() const { return min_.y_; }
 
     /// Return right coordinate.
-    /// @property
     float Right() const { return max_.x_; }
 
     /// Return bottom coordinate.
-    /// @property
     float Bottom() const { return max_.y_; }
 
     /// Minimum vector.
@@ -387,15 +380,12 @@ public:
     }
 
     /// Return size.
-    /// @property
     IntVector2 Size() const { return IntVector2(Width(), Height()); }
 
     /// Return width.
-    /// @property
     int Width() const { return right_ - left_; }
 
     /// Return height.
-    /// @property
     int Height() const { return bottom_ - top_; }
 
     /// Test whether a point is inside.

--- a/source/dviglo/math/string_hash.h
+++ b/source/dviglo/math/string_hash.h
@@ -78,7 +78,6 @@ public:
     explicit operator bool() const { return value_ != 0; }
 
     /// Return hash value.
-    /// @property
     hash32 Value() const { return value_; }
 
     /// Return as string.

--- a/source/dviglo/math/vector2.h
+++ b/source/dviglo/math/vector2.h
@@ -287,11 +287,9 @@ public:
     }
 
     /// Return length.
-    /// @property
     float Length() const { return sqrtf(x_ * x_ + y_ * y_); }
 
     /// Return squared length.
-    /// @property
     float LengthSquared() const { return x_ * x_ + y_ * y_; }
 
     /// Calculate dot product.

--- a/source/dviglo/math/vector3.h
+++ b/source/dviglo/math/vector3.h
@@ -334,11 +334,9 @@ public:
     }
 
     /// Return length.
-    /// @property
     float Length() const { return sqrtf(x_ * x_ + y_ * y_ + z_ * z_); }
 
     /// Return squared length.
-    /// @property
     float LengthSquared() const { return x_ * x_ + y_ * y_ + z_ * z_; }
 
     /// Calculate dot product.

--- a/source/dviglo/navigation/crowd_agent.h
+++ b/source/dviglo/navigation/crowd_agent.h
@@ -79,107 +79,79 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Submit a new target position request for this agent.
-    /// @property
     void SetTargetPosition(const Vector3& position);
     /// Submit a new target velocity request for this agent.
-    /// @property
     void SetTargetVelocity(const Vector3& velocity);
     /// Reset any target request for the specified agent. Note that the agent will continue to move into the current direction; set a zero target velocity to actually stop.
     void ResetTarget();
     /// Update the node position. When set to false, the node position should be updated by other means (e.g. using Physics) in response to the E_CROWD_AGENT_REPOSITION event.
-    /// @property
     void SetUpdateNodePosition(bool unodepos);
     /// Set the agent's max acceleration.
-    /// @property
     void SetMaxAccel(float maxAccel);
     /// Set the agent's max velocity.
-    /// @property
     void SetMaxSpeed(float maxSpeed);
     /// Set the agent's radius.
-    /// @property
     void SetRadius(float radius);
     /// Set the agent's height.
-    /// @property
     void SetHeight(float height);
     /// Set the agent's query filter type.
-    /// @property
     void SetQueryFilterType(unsigned queryFilterType);
     /// Set the agent's obstacle avoidance type.
-    /// @property
     void SetObstacleAvoidanceType(unsigned obstacleAvoidanceType);
     /// Set the agent's navigation quality.
-    /// @property
     void SetNavigationQuality(NavigationQuality val);
     /// Set the agent's navigation pushiness.
-    /// @property
     void SetNavigationPushiness(NavigationPushiness val);
 
     /// Return the agent's position.
-    /// @property
     Vector3 GetPosition() const;
     /// Return the agent's desired velocity.
-    /// @property
     Vector3 GetDesiredVelocity() const;
     /// Return the agent's actual velocity.
-    /// @property
     Vector3 GetActualVelocity() const;
 
     /// Return the agent's requested target position.
-    /// @property
     const Vector3& GetTargetPosition() const { return targetPosition_; }
 
     /// Return the agent's requested target velocity.
-    /// @property
     const Vector3& GetTargetVelocity() const { return targetVelocity_; }
 
     /// Return the agent's requested target type, if any.
-    /// @property
     CrowdAgentRequestedTarget GetRequestedTargetType() const { return requestedTargetType_; }
 
     /// Return the agent's  state.
-    /// @property
     CrowdAgentState GetAgentState() const;
     /// Return the agent's target state.
-    /// @property
     CrowdAgentTargetState GetTargetState() const;
 
     /// Return true when the node's position should be updated by the CrowdManager.
-    /// @property
     bool GetUpdateNodePosition() const { return updateNodePosition_; }
 
     /// Return the agent id.
     int GetAgentCrowdId() const { return agentCrowdId_; }
 
     /// Get the agent's max acceleration.
-    /// @property
     float GetMaxAccel() const { return maxAccel_; }
 
     /// Get the agent's max velocity.
-    /// @property
     float GetMaxSpeed() const { return maxSpeed_; }
 
     /// Get the agent's radius.
-    /// @property
     float GetRadius() const { return radius_; }
 
     /// Get the agent's height.
-    /// @property
     float GetHeight() const { return height_; }
 
     /// Get the agent's query filter type.
-    /// @property
     unsigned GetQueryFilterType() const { return queryFilterType_; }
 
     /// Get the agent's obstacle avoidance type.
-    /// @property
     unsigned GetObstacleAvoidanceType() const { return obstacleAvoidanceType_; }
 
     /// Get the agent's navigation quality.
-    /// @property
     NavigationQuality GetNavigationQuality() const { return navQuality_; }
 
     /// Get the agent's navigation pushiness.
-    /// @property
     NavigationPushiness GetNavigationPushiness() const { return navPushiness_; }
 
     /// Return true when the agent has a target.
@@ -190,7 +162,6 @@ public:
     /// @property{get_arrived}
     bool HasArrived() const;
     /// Return true when the agent is in crowd (being managed by a crowd manager).
-    /// @property
     bool IsInCrowd() const;
 
 protected:

--- a/source/dviglo/navigation/crowd_agent.h
+++ b/source/dviglo/navigation/crowd_agent.h
@@ -155,11 +155,9 @@ public:
     NavigationPushiness GetNavigationPushiness() const { return navPushiness_; }
 
     /// Return true when the agent has a target.
-    /// @property{get_requestedTarget}
     bool HasRequestedTarget() const { return requestedTargetType_ != CA_REQUESTEDTARGET_NONE; }
 
     /// Return true when the agent has arrived at its target.
-    /// @property{get_arrived}
     bool HasArrived() const;
     /// Return true when the agent is in crowd (being managed by a crowd manager).
     bool IsInCrowd() const;

--- a/source/dviglo/navigation/crowd_manager.h
+++ b/source/dviglo/navigation/crowd_manager.h
@@ -72,7 +72,6 @@ public:
     /// Set the maximum radius of any agent.
     void SetMaxAgentRadius(float maxAgentRadius);
     /// Assigns the navigation mesh for the crowd.
-    /// @property{set_navMesh}
     void SetNavigationMesh(NavigationMesh* navMesh);
     /// Set all the query filter types configured in the crowd based on the corresponding attribute.
     void SetQueryFilterTypesAttr(const VariantVector& value);
@@ -111,7 +110,6 @@ public:
     float GetMaxAgentRadius() const { return maxAgentRadius_; }
 
     /// Get the Navigation mesh assigned to the crowd.
-    /// @property{get_navMesh}
     NavigationMesh* GetNavigationMesh() const { return navigationMesh_; }
 
     /// Get the number of configured query filter types.

--- a/source/dviglo/navigation/crowd_manager.h
+++ b/source/dviglo/navigation/crowd_manager.h
@@ -68,10 +68,8 @@ public:
     /// Reset any crowd target for all crowd agents found in the specified node. Defaulted to scene node.
     void ResetCrowdTarget(Node* node = nullptr);
     /// Set the maximum number of agents.
-    /// @property
     void SetMaxAgents(i32 maxAgents);
     /// Set the maximum radius of any agent.
-    /// @property
     void SetMaxAgentRadius(float maxAgentRadius);
     /// Assigns the navigation mesh for the crowd.
     /// @property{set_navMesh}
@@ -107,11 +105,9 @@ public:
     Vector3 Raycast(const Vector3& start, const Vector3& end, int queryFilterType, Vector3* hitNormal = nullptr);
 
     /// Get the maximum number of agents.
-    /// @property
     i32 GetMaxAgents() const { return maxAgents_; }
 
     /// Get the maximum radius of any agent.
-    /// @property
     float GetMaxAgentRadius() const { return maxAgentRadius_; }
 
     /// Get the Navigation mesh assigned to the crowd.
@@ -119,11 +115,9 @@ public:
     NavigationMesh* GetNavigationMesh() const { return navigationMesh_; }
 
     /// Get the number of configured query filter types.
-    /// @property
     unsigned GetNumQueryFilterTypes() const { return numQueryFilterTypes_; }
 
     /// Get the number of configured area in the specified query filter type.
-    /// @property
     unsigned GetNumAreas(unsigned queryFilterType) const;
     /// Return all the filter types configured in the crowd as attribute.
     VariantVector GetQueryFilterTypesAttr() const;
@@ -135,7 +129,6 @@ public:
     float GetAreaCost(unsigned queryFilterType, unsigned areaID) const;
 
     /// Get the number of configured obstacle avoidance types.
-    /// @property
     unsigned GetNumObstacleAvoidanceTypes() const { return numObstacleAvoidanceTypes_; }
 
     /// Return all the obstacle avoidance types configured in the crowd as attribute.

--- a/source/dviglo/navigation/dynamic_navigation_mesh.h
+++ b/source/dviglo/navigation/dynamic_navigation_mesh.h
@@ -68,25 +68,19 @@ public:
     Vector<byte> GetNavigationDataAttr() const override;
 
     /// Set the maximum number of obstacles allowed.
-    /// @property
     void SetMaxObstacles(unsigned maxObstacles) { maxObstacles_ = maxObstacles; }
     /// Set the maximum number of layers that navigation construction can create.
-    /// @property
     void SetMaxLayers(unsigned maxLayers);
 
     /// Return the maximum number of obstacles allowed.
-    /// @property
     unsigned GetMaxObstacles() const { return maxObstacles_; }
     /// Return the maximum number of layers permitted to build.
-    /// @property
     unsigned GetMaxLayers() const { return maxLayers_; }
 
     /// Draw debug geometry for Obstacles.
-    /// @property
     void SetDrawObstacles(bool enable) { drawObstacles_ = enable; }
 
     /// Return whether to draw Obstacles.
-    /// @property
     bool GetDrawObstacles() const { return drawObstacles_; }
 
 protected:

--- a/source/dviglo/navigation/nav_area.h
+++ b/source/dviglo/navigation/nav_area.h
@@ -27,23 +27,18 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Get the area id for this volume.
-    /// @property
     unsigned GetAreaID() const { return (unsigned)areaID_; }
 
     /// Set the area id for this volume.
-    /// @property
     void SetAreaID(unsigned newID);
 
     /// Get the bounding box of this navigation area, in local space.
-    /// @property
     BoundingBox GetBoundingBox() const { return boundingBox_; }
 
     /// Set the bounding box of this area, in local space.
-    /// @property
     void SetBoundingBox(const BoundingBox& bnds) { boundingBox_ = bnds; }
 
     /// Get the bounds of this navigation area in world space.
-    /// @property
     BoundingBox GetWorldBoundingBox() const;
 
 private:

--- a/source/dviglo/navigation/navigable.h
+++ b/source/dviglo/navigation/navigable.h
@@ -24,11 +24,9 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set whether geometry is automatically collected from child nodes. Default true.
-    /// @property
     void SetRecursive(bool enable);
 
     /// Return whether geometry is automatically collected from child nodes.
-    /// @property
     bool IsRecursive() const { return recursive_; }
 
 private:

--- a/source/dviglo/navigation/navigation_mesh.h
+++ b/source/dviglo/navigation/navigation_mesh.h
@@ -92,46 +92,32 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set tile size.
-    /// @property
     void SetTileSize(int size);
     /// Set cell size.
-    /// @property
     void SetCellSize(float size);
     /// Set cell height.
-    /// @property
     void SetCellHeight(float height);
     /// Set navigation agent height.
-    /// @property
     void SetAgentHeight(float height);
     /// Set navigation agent radius.
-    /// @property
     void SetAgentRadius(float radius);
     /// Set navigation agent max vertical climb.
-    /// @property
     void SetAgentMaxClimb(float maxClimb);
     /// Set navigation agent max slope.
-    /// @property
     void SetAgentMaxSlope(float maxSlope);
     /// Set region minimum size.
-    /// @property
     void SetRegionMinSize(float size);
     /// Set region merge size.
-    /// @property
     void SetRegionMergeSize(float size);
     /// Set edge max length.
-    /// @property
     void SetEdgeMaxLength(float length);
     /// Set edge max error.
-    /// @property
     void SetEdgeMaxError(float error);
     /// Set detail sampling distance.
-    /// @property
     void SetDetailSampleDistance(float distance);
     /// Set detail sampling maximum error.
-    /// @property
     void SetDetailSampleMaxError(float error);
     /// Set padding of the navigation mesh bounding box. Having enough padding allows to add geometry on the extremities of the navigation mesh when doing partial rebuilds.
-    /// @property
     void SetPadding(const Vector3& padding);
     /// Set the cost of an area.
     void SetAreaCost(unsigned areaID, float cost);
@@ -195,86 +181,66 @@ public:
     void SetMeshName(const String& newName);
 
     /// Return tile size.
-    /// @property
     int GetTileSize() const { return tileSize_; }
 
     /// Return cell size.
-    /// @property
     float GetCellSize() const { return cellSize_; }
 
     /// Return cell height.
-    /// @property
     float GetCellHeight() const { return cellHeight_; }
 
     /// Return navigation agent height.
-    /// @property
     float GetAgentHeight() const { return agentHeight_; }
 
     /// Return navigation agent radius.
-    /// @property
     float GetAgentRadius() const { return agentRadius_; }
 
     /// Return navigation agent max vertical climb.
-    /// @property
     float GetAgentMaxClimb() const { return agentMaxClimb_; }
 
     /// Return navigation agent max slope.
-    /// @property
     float GetAgentMaxSlope() const { return agentMaxSlope_; }
 
     /// Return region minimum size.
-    /// @property
     float GetRegionMinSize() const { return regionMinSize_; }
 
     /// Return region merge size.
-    /// @property
     float GetRegionMergeSize() const { return regionMergeSize_; }
 
     /// Return edge max length.
-    /// @property
     float GetEdgeMaxLength() const { return edgeMaxLength_; }
 
     /// Return edge max error.
-    /// @property
     float GetEdgeMaxError() const { return edgeMaxError_; }
 
     /// Return detail sampling distance.
-    /// @property
     float GetDetailSampleDistance() const { return detailSampleDistance_; }
 
     /// Return detail sampling maximum error.
-    /// @property
     float GetDetailSampleMaxError() const { return detailSampleMaxError_; }
 
     /// Return navigation mesh bounding box padding.
-    /// @property
     const Vector3& GetPadding() const { return padding_; }
 
     /// Get the current cost of an area.
     float GetAreaCost(unsigned areaID) const;
 
     /// Return whether has been initialized with valid navigation data.
-    /// @property
     bool IsInitialized() const { return navMesh_ != nullptr; }
 
     /// Return local space bounding box of the navigation mesh.
-    /// @property
     const BoundingBox& GetBoundingBox() const { return boundingBox_; }
 
     /// Return world space bounding box of the navigation mesh.
-    /// @property
     BoundingBox GetWorldBoundingBox() const;
 
     /// Return number of tiles.
-    /// @property
     IntVector2 GetNumTiles() const { return IntVector2(numTilesX_, numTilesZ_); }
 
     /// Set the partition type used for polygon generation.
-    /// @property
     void SetPartitionType(NavmeshPartitionType partitionType);
 
     /// Return Partition Type.
-    /// @property
     NavmeshPartitionType GetPartitionType() const { return partitionType_; }
 
     /// Set navigation data attribute.
@@ -283,19 +249,15 @@ public:
     virtual Vector<byte> GetNavigationDataAttr() const;
 
     /// Draw debug geometry for OffMeshConnection components.
-    /// @property
     void SetDrawOffMeshConnections(bool enable) { drawOffMeshConnections_ = enable; }
 
     /// Return whether to draw OffMeshConnection components.
-    /// @property
     bool GetDrawOffMeshConnections() const { return drawOffMeshConnections_; }
 
     /// Draw debug geometry for NavArea components.
-    /// @property
     void SetDrawNavAreas(bool enable) { drawNavAreas_ = enable; }
 
     /// Return whether to draw NavArea components.
-    /// @property
     bool GetDrawNavAreas() const { return drawNavAreas_; }
 
 private:

--- a/source/dviglo/navigation/obstacle.h
+++ b/source/dviglo/navigation/obstacle.h
@@ -33,19 +33,15 @@ public:
     void OnSetEnabled() override;
 
     /// Get the height of this obstacle.
-    /// @property
     float GetHeight() const { return height_; }
 
     /// Set the height of this obstacle.
-    /// @property
     void SetHeight(float newHeight);
 
     /// Get the blocking radius of this obstacle.
-    /// @property
     float GetRadius() const { return radius_; }
 
     /// Set the blocking radius of this obstacle.
-    /// @property
     void SetRadius(float newRadius);
 
     /// Get the internal obstacle ID.

--- a/source/dviglo/navigation/obstacle.h
+++ b/source/dviglo/navigation/obstacle.h
@@ -45,7 +45,6 @@ public:
     void SetRadius(float newRadius);
 
     /// Get the internal obstacle ID.
-    /// @property{get_obstacleId}
     unsigned GetObstacleID() const { return obstacleId_; }
 
     /// Render debug information.

--- a/source/dviglo/navigation/off_mesh_connection.h
+++ b/source/dviglo/navigation/off_mesh_connection.h
@@ -29,39 +29,29 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set endpoint node.
-    /// @property
     void SetEndPoint(Node* node);
     /// Set radius.
-    /// @property
     void SetRadius(float radius);
     /// Set bidirectional flag. Default true.
-    /// @property
     void SetBidirectional(bool enabled);
     /// Set a user assigned mask.
-    /// @property
     void SetMask(unsigned newMask);
     /// Sets the assigned area Id for the connection.
-    /// @property
     void SetAreaID(unsigned newAreaID);
 
     /// Return endpoint node.
-    /// @property
     Node* GetEndPoint() const;
 
     /// Return radius.
-    /// @property
     float GetRadius() const { return radius_; }
 
     /// Return whether is bidirectional.
-    /// @property
     bool IsBidirectional() const { return bidirectional_; }
 
     /// Return the user assigned mask.
-    /// @property
     unsigned GetMask() const { return mask_; }
 
     /// Return the user assigned area ID.
-    /// @property
     unsigned GetAreaID() const { return areaId_; }
 
 private:

--- a/source/dviglo/network/connection.h
+++ b/source/dviglo/network/connection.h
@@ -118,22 +118,18 @@ public:
     /// Send a remote event with the specified node as sender.
     void SendRemoteEvent(Node* node, StringHash eventType, bool inOrder, const VariantMap& eventData = Variant::emptyVariantMap);
     /// Assign scene. On the server, this will cause the client to load it.
-    /// @property
     void SetScene(Scene* newScene);
     /// Assign identity. Called by Network.
     void SetIdentity(const VariantMap& identity);
     /// Set new controls.
     void SetControls(const Controls& newControls);
     /// Set the observer position for interest management, to be sent to the server.
-    /// @property
     void SetPosition(const Vector3& position);
     /// Set the observer rotation for interest management, to be sent to the server. Note: not used by the NetworkPriority component.
-    /// @property
     void SetRotation(const Quaternion& rotation);
     /// Set the connection pending status. Called by Network.
     void SetConnectPending(bool connectPending);
     /// Set whether to log data in/out statistics.
-    /// @property
     void SetLogStatistics(bool enable);
     /// Disconnect. If wait time is non-zero, will block while waiting for disconnect to finish.
     void Disconnect(int waitMSec = 0);
@@ -163,7 +159,6 @@ public:
     VariantMap& GetIdentity() { return identity_; }
 
     /// Return the scene used by this connection.
-    /// @property
     Scene* GetScene() const;
 
     /// Return the client controls of this connection.
@@ -173,75 +168,57 @@ public:
     unsigned char GetTimeStamp() const { return timeStamp_; }
 
     /// Return the observer position sent by the client for interest management.
-    /// @property
     const Vector3& GetPosition() const { return position_; }
 
     /// Return the observer rotation sent by the client for interest management.
-    /// @property
     const Quaternion& GetRotation() const { return rotation_; }
 
     /// Return whether is a client connection.
-    /// @property
     bool IsClient() const { return isClient_; }
 
     /// Return whether is fully connected.
-    /// @property
     bool IsConnected() const;
 
     /// Return whether connection is pending.
-    /// @property
     bool IsConnectPending() const { return connectPending_; }
 
     /// Return whether the scene is loaded and ready to receive server updates.
-    /// @property
     bool IsSceneLoaded() const { return sceneLoaded_; }
 
     /// Return whether to log data in/out statistics.
-    /// @property
     bool GetLogStatistics() const { return logStatistics_; }
 
     /// Return remote address.
-    /// @property
     String GetAddress() const;
 
     /// Return remote port.
-    /// @property
     unsigned short GetPort() const { return port_; }
 
     /// Return the connection's round trip time in milliseconds.
-    /// @property
     float GetRoundTripTime() const;
 
     /// Return the time since last received data from the remote host in milliseconds.
-    /// @property
     unsigned GetLastHeardTime() const;
 
     /// Return bytes received per second.
-    /// @property
     float GetBytesInPerSec() const;
 
     /// Return bytes sent per second.
-    /// @property
     float GetBytesOutPerSec() const;
 
     /// Return packets received per second.
-    /// @property
     int GetPacketsInPerSec() const;
 
     /// Return packets sent per second.
-    /// @property
     int GetPacketsOutPerSec() const;
 
     /// Return an address:port string.
     String ToString() const;
     /// Return number of package downloads remaining.
-    /// @property
     unsigned GetNumDownloads() const;
     /// Return name of current package download, or empty if no downloads.
-    /// @property
     const String& GetDownloadName() const;
     /// Return progress of current package download, or 1.0 if no downloads.
-    /// @property
     float GetDownloadProgress() const;
     /// Trigger client connection to download a package file from the server. Can be used to download additional resource packages when client is already joined in a scene. The package must have been added as a requirement to the scene the client is joined in, or else the eventual download will fail.
     void SendPackageToClient(PackageFile* package);

--- a/source/dviglo/network/http_request.h
+++ b/source/dviglo/network/http_request.h
@@ -48,21 +48,16 @@ public:
     const String& GetURL() const { return url_; }
 
     /// Return verb used in the request. Default GET if empty verb specified on construction.
-    /// @property
     const String& GetVerb() const { return verb_; }
 
     /// Return error. Only non-empty in the error state.
-    /// @property
     String GetError() const;
     /// Return connection state.
-    /// @property
     HttpRequestState GetState() const;
     /// Return amount of bytes in the read buffer.
-    /// @property
     i32 GetAvailableSize() const;
 
     /// Return whether connection is in the open state.
-    /// @property
     bool IsOpen() const { return GetState() == HTTP_OPEN; }
 
 private:

--- a/source/dviglo/network/http_request.h
+++ b/source/dviglo/network/http_request.h
@@ -44,7 +44,6 @@ public:
     bool IsEof() const override;
 
     /// Return URL used in the request.
-    /// @property{get_url}
     const String& GetURL() const { return url_; }
 
     /// Return verb used in the request. Default GET if empty verb specified on construction.

--- a/source/dviglo/network/network.h
+++ b/source/dviglo/network/network.h
@@ -53,7 +53,6 @@ public:
     /// Start NAT punchtrough client to allow remote connections.
     void StartNATClient();
     /// Get local server GUID.
-    /// @property{get_guid}
     const String& GetGUID() const { return guid_; }
     /// Attempt to connect to NAT server.
     void AttemptNATPunchtrough(const String& guid, Scene* scene, const VariantMap& identity = Variant::emptyVariantMap);

--- a/source/dviglo/network/network.h
+++ b/source/dviglo/network/network.h
@@ -68,13 +68,10 @@ public:
     /// Broadcast a remote event with the specified node as a sender. Is sent to all client connections in the node's scene.
     void BroadcastRemoteEvent(Node* node, StringHash eventType, bool inOrder, const VariantMap& eventData = Variant::emptyVariantMap);
     /// Set network update FPS.
-    /// @property
     void SetUpdateFps(int fps);
     /// Set simulated latency in milliseconds. This adds a fixed delay before sending each packet.
-    /// @property
     void SetSimulatedLatency(int ms);
     /// Set simulated packet loss probability between 0.0 - 1.0.
-    /// @property
     void SetSimulatedPacketLoss(float probability);
     /// Register a remote event as allowed to be received. There is also a fixed blacklist of events that can not be allowed in any case, such as ConsoleCommand.
     void RegisterRemoteEvent(StringHash eventType);
@@ -83,7 +80,6 @@ public:
     /// Unregister all remote events.
     void UnregisterAllRemoteEvents();
     /// Set the package download cache directory.
-    /// @property
     void SetPackageCacheDir(const String& path);
     /// Trigger all client connections in the specified scene to download a package file from the server. Can be used to download additional resource packages when clients are already joined in the scene. The package must have been added as a requirement to the scene, or else the eventual download will fail.
     void SendPackageToClients(Scene* scene, PackageFile* package);
@@ -92,33 +88,26 @@ public:
     /// Ban specific IP addresses.
     void BanAddress(const String& address);
     /// Return network update FPS.
-    /// @property
     int GetUpdateFps() const { return updateFps_; }
 
     /// Return simulated latency in milliseconds.
-    /// @property
     int GetSimulatedLatency() const { return simulatedLatency_; }
 
     /// Return simulated packet loss probability.
-    /// @property
     float GetSimulatedPacketLoss() const { return simulatedPacketLoss_; }
 
     /// Return a client or server connection by RakNet connection address, or null if none exist.
     Connection* GetConnection(const SLNet::AddressOrGUID& connection) const;
     /// Return the connection to the server. Null if not connected.
-    /// @property
     Connection* GetServerConnection() const;
     /// Return all client connections.
-    /// @property
     Vector<SharedPtr<Connection>> GetClientConnections() const;
     /// Return whether the server is running.
-    /// @property
     bool IsServerRunning() const;
     /// Return whether a remote event is allowed to be received.
     bool CheckRemoteEvent(StringHash eventType) const;
 
     /// Return the package download cache directory.
-    /// @property
     const String& GetPackageCacheDir() const { return packageCacheDir_; }
 
     /// Process incoming messages from connections. Called by HandleBeginFrame.

--- a/source/dviglo/network/network_priority.h
+++ b/source/dviglo/network/network_priority.h
@@ -24,32 +24,24 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set base priority. Default 100 (send updates at full frequency).
-    /// @property
     void SetBasePriority(float priority);
     /// Set priority reduction distance factor. Default 0 (no effect).
-    /// @property
     void SetDistanceFactor(float factor);
     /// Set minimum priority. Default 0 (no updates when far away enough).
-    /// @property
     void SetMinPriority(float priority);
     /// Set whether updates to owner should be sent always at full rate. Default true.
-    /// @property
     void SetAlwaysUpdateOwner(bool enable);
 
     /// Return base priority.
-    /// @property
     float GetBasePriority() const { return basePriority_; }
 
     /// Return priority reduction distance factor.
-    /// @property
     float GetDistanceFactor() const { return distanceFactor_; }
 
     /// Return minimum priority.
-    /// @property
     float GetMinPriority() const { return minPriority_; }
 
     /// Return whether updates to owner should be sent always at full rate.
-    /// @property
     bool GetAlwaysUpdateOwner() const { return alwaysUpdateOwner_; }
 
     /// Increment and check priority accumulator. Return true if should update. Called by Connection.

--- a/source/dviglo/physics/collision_shape.h
+++ b/source/dviglo/physics/collision_shape.h
@@ -179,27 +179,20 @@ public:
     /// Set as a terrain. Only works if the same scene node contains a Terrain component.
     void SetTerrain(i32 lodLevel = 0);
     /// Set shape type.
-    /// @property
     void SetShapeType(ShapeType type);
     /// Set shape size.
-    /// @property
     void SetSize(const Vector3& size);
     /// Set offset position.
-    /// @property
     void SetPosition(const Vector3& position);
     /// Set offset rotation.
-    /// @property
     void SetRotation(const Quaternion& rotation);
     /// Set offset transform.
     void SetTransform(const Vector3& position, const Quaternion& rotation);
     /// Set collision margin.
-    /// @property
     void SetMargin(float margin);
     /// Set triangle mesh / convex hull model.
-    /// @property
     void SetModel(Model* model);
     /// Set model LOD level.
-    /// @property
     void SetLodLevel(i32 lodLevel);
 
     /// Return Bullet collision shape.
@@ -212,35 +205,27 @@ public:
     PhysicsWorld* GetPhysicsWorld() const { return physicsWorld_; }
 
     /// Return shape type.
-    /// @property
     ShapeType GetShapeType() const { return shapeType_; }
 
     /// Return shape size.
-    /// @property
     const Vector3& GetSize() const { return size_; }
 
     /// Return offset position.
-    /// @property
     const Vector3& GetPosition() const { return position_; }
 
     /// Return offset rotation.
-    /// @property
     const Quaternion& GetRotation() const { return rotation_; }
 
     /// Return collision margin.
-    /// @property
     float GetMargin() const { return margin_; }
 
     /// Return triangle mesh / convex hull model.
-    /// @property
     Model* GetModel() const { return model_; }
 
     /// Return model LOD level.
-    /// @property
     i32 GetLodLevel() const { return lodLevel_; }
 
     /// Return world-space bounding box.
-    /// @property
     BoundingBox GetWorldBoundingBox() const;
 
     /// Update the new collision shape to the RigidBody.

--- a/source/dviglo/physics/constraint.h
+++ b/source/dviglo/physics/constraint.h
@@ -76,10 +76,8 @@ public:
     /// Set low limit. Interpretation is constraint type specific.
     void SetLowLimit(const Vector2& limit);
     /// Set constraint error reduction parameter. Zero = leave to default.
-    /// @property{set_erp}
     void SetERP(float erp);
     /// Set constraint force mixing parameter. Zero = leave to default.
-    /// @property{set_cfm}
     void SetCFM(float cfm);
     /// Set whether to disable collisions between connected bodies.
     void SetDisableCollision(bool disable);
@@ -121,11 +119,9 @@ public:
     const Vector2& GetLowLimit() const { return lowLimit_; }
 
     /// Return constraint error reduction parameter.
-    /// @property{get_erp}
     float GetERP() const { return erp_; }
 
     /// Return constraint force mixing parameter.
-    /// @property{get_cfm}
     float GetCFM() const { return cfm_; }
 
     /// Return whether collisions between connected bodies are disabled.

--- a/source/dviglo/physics/constraint.h
+++ b/source/dviglo/physics/constraint.h
@@ -54,37 +54,26 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set constraint type and recreate the constraint.
-    /// @property
     void SetConstraintType(ConstraintType type);
     /// Set other body to connect to. Set to null to connect to the static world.
-    /// @property
     void SetOtherBody(RigidBody* body);
     /// Set constraint position relative to own body.
-    /// @property
     void SetPosition(const Vector3& position);
     /// Set constraint rotation relative to own body.
-    /// @property
     void SetRotation(const Quaternion& rotation);
     /// Set constraint rotation relative to own body by specifying the axis.
-    /// @property
     void SetAxis(const Vector3& axis);
     /// Set constraint position relative to the other body. If connected to the static world, is a world space position.
-    /// @property
     void SetOtherPosition(const Vector3& position);
     /// Set constraint rotation relative to the other body. If connected to the static world, is a world space rotation.
-    /// @property
     void SetOtherRotation(const Quaternion& rotation);
     /// Set constraint rotation relative to the other body by specifying the axis.
-    /// @property
     void SetOtherAxis(const Vector3& axis);
     /// Set constraint world space position. Resets both own and other body relative position, ie. zeroes the constraint error.
-    /// @property
     void SetWorldPosition(const Vector3& position);
     /// Set high limit. Interpretation is constraint type specific.
-    /// @property
     void SetHighLimit(const Vector2& limit);
     /// Set low limit. Interpretation is constraint type specific.
-    /// @property
     void SetLowLimit(const Vector2& limit);
     /// Set constraint error reduction parameter. Zero = leave to default.
     /// @property{set_erp}
@@ -93,7 +82,6 @@ public:
     /// @property{set_cfm}
     void SetCFM(float cfm);
     /// Set whether to disable collisions between connected bodies.
-    /// @property
     void SetDisableCollision(bool disable);
 
     /// Return physics world.
@@ -103,43 +91,33 @@ public:
     btTypedConstraint* GetConstraint() const { return constraint_.get(); }
 
     /// Return constraint type.
-    /// @property
     ConstraintType GetConstraintType() const { return constraintType_; }
 
     /// Return rigid body in own scene node.
-    /// @property
     RigidBody* GetOwnBody() const { return ownBody_; }
 
     /// Return the other rigid body. May be null if connected to the static world.
-    /// @property
     RigidBody* GetOtherBody() const { return otherBody_; }
 
     /// Return constraint position relative to own body.
-    /// @property
     const Vector3& GetPosition() const { return position_; }
 
     /// Return constraint rotation relative to own body.
-    /// @property
     const Quaternion& GetRotation() const { return rotation_; }
 
     /// Return constraint position relative to other body.
-    /// @property
     const Vector3& GetOtherPosition() const { return otherPosition_; }
 
     /// Return constraint rotation relative to other body.
-    /// @property
     const Quaternion& GetOtherRotation() const { return otherRotation_; }
 
     /// Return constraint world position, calculated from own body.
-    /// @property
     Vector3 GetWorldPosition() const;
 
     /// Return high limit.
-    /// @property
     const Vector2& GetHighLimit() const { return highLimit_; }
 
     /// Return low limit.
-    /// @property
     const Vector2& GetLowLimit() const { return lowLimit_; }
 
     /// Return constraint error reduction parameter.
@@ -151,7 +129,6 @@ public:
     float GetCFM() const { return cfm_; }
 
     /// Return whether collisions between connected bodies are disabled.
-    /// @property
     bool GetDisableCollision() const { return disableCollision_; }
 
     /// Release the constraint.

--- a/source/dviglo/physics/physics_world.h
+++ b/source/dviglo/physics/physics_world.h
@@ -151,28 +151,20 @@ public:
     /// Refresh collisions only without updating dynamics.
     void UpdateCollisions();
     /// Set simulation substeps per second.
-    /// @property
     void SetFps(i32 fps);
     /// Set gravity.
-    /// @property
     void SetGravity(const Vector3& gravity);
     /// Set maximum number of physics substeps per frame. 0 (default) is unlimited. Positive values cap the amount. Use a negative value to enable an adaptive timestep. This may cause inconsistent physics behavior.
-    /// @property
     void SetMaxSubSteps(int num);
     /// Set number of constraint solver iterations.
-    /// @property
     void SetNumIterations(int num);
     /// Enable or disable automatic physics simulation during scene update. Enabled by default.
-    /// @property
     void SetUpdateEnabled(bool enable);
     /// Set whether to interpolate between simulation steps.
-    /// @property
     void SetInterpolation(bool enable);
     /// Set whether to use Bullet's internal edge utility for trimesh collisions. Disabled by default.
-    /// @property
     void SetInternalEdge(bool enable);
     /// Set split impulse collision mode. This is more accurate, but slower. Disabled by default.
-    /// @property
     void SetSplitImpulse(bool enable);
     /// Set maximum angular velocity for network replication.
     void SetMaxNetworkAngularVelocity(float velocity);
@@ -205,35 +197,27 @@ public:
     void GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body);
 
     /// Return gravity.
-    /// @property
     Vector3 GetGravity() const;
 
     /// Return maximum number of physics substeps per frame.
-    /// @property
     int GetMaxSubSteps() const { return maxSubSteps_; }
 
     /// Return number of constraint solver iterations.
-    /// @property
     int GetNumIterations() const;
 
     /// Return whether physics world will automatically simulate during scene update.
-    /// @property
     bool IsUpdateEnabled() const { return updateEnabled_; }
 
     /// Return whether interpolation between simulation steps is enabled.
-    /// @property
     bool GetInterpolation() const { return interpolation_; }
 
     /// Return whether Bullet's internal edge utility for trimesh collisions is enabled.
-    /// @property
     bool GetInternalEdge() const { return internalEdge_; }
 
     /// Return whether split impulse collision mode is enabled.
-    /// @property
     bool GetSplitImpulse() const;
 
     /// Return simulation steps per second.
-    /// @property
     i32 GetFps() const { return fps_; }
 
     /// Return maximum angular velocity for network replication.

--- a/source/dviglo/physics/raycast_vehicle.h
+++ b/source/dviglo/physics/raycast_vehicle.h
@@ -71,15 +71,12 @@ public:
     /// Set wheel axle vector.
     void SetWheelAxle(int wheel, Vector3 axle);
     /// Set side speed which is considered sliding.
-    /// @property
     void SetMaxSideSlipSpeed(float speed);
     /// Set cumulative skid info.
     void SetWheelSkidInfoCumulative(int wheel, float skid);
     /// Set revolution per minute value for when wheel doesn't touch ground. If set to 0 (or not set), calculated from engine force (probably not what you want).
-    /// @property
     void SetInAirRPM(float rpm);
     /// Set the coordinate system. The default is (0, 1, 2).
-    /// @property
     void SetCoordinateSystem(const IntVector3& coordinateSystem = RIGHT_FORWARD_UP);
     /// Init the vehicle component after creation.
     void Init();
@@ -97,7 +94,6 @@ public:
     /// Get wheel connection point relative to RigidBody.
     Vector3 GetWheelConnectionPoint(int wheel) const;
     /// Get number of attached wheels.
-    /// @property
     int GetNumWheels() const;
     /// Get node of the wheel.
     Node* GetWheelNode(int wheel) const;
@@ -132,7 +128,6 @@ public:
     /// Get wheel slide speed.
     float GetWheelSideSlipSpeed(int wheel) const;
     /// Get side speed which is considered sliding.
-    /// @property
     float GetMaxSideSlipSpeed() const;
     /// Sliding factor 0 <= x <= 1.
     float GetWheelSkidInfo(int wheel) const;
@@ -147,10 +142,8 @@ public:
     /// Get contact normal.
     Vector3 GetContactNormal(int wheel) const;
     /// Get revolution per minute value for when wheel doesn't touch ground.
-    /// @property
     float GetInAirRPM() const;
     /// Get the coordinate system.
-    /// @property
     IntVector3 GetCoordinateSystem() const { return coordinateSystem_; }
 
     /// Get wheel data attribute for serialization.

--- a/source/dviglo/physics/rigid_body.h
+++ b/source/dviglo/physics/rigid_body.h
@@ -60,83 +60,58 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set mass. Zero mass makes the body static.
-    /// @property
     void SetMass(float mass);
     /// Set rigid body position in world space.
-    /// @property
     void SetPosition(const Vector3& position);
     /// Set rigid body rotation in world space.
-    /// @property
     void SetRotation(const Quaternion& rotation);
     /// Set rigid body position and rotation in world space as an atomic operation.
     void SetTransform(const Vector3& position, const Quaternion& rotation);
     /// Set linear velocity.
-    /// @property
     void SetLinearVelocity(const Vector3& velocity);
     /// Set linear degrees of freedom. Use 1 to enable an axis or 0 to disable. Default is all axes enabled (1, 1, 1).
-    /// @property
     void SetLinearFactor(const Vector3& factor);
     /// Set linear velocity deactivation threshold.
-    /// @property
     void SetLinearRestThreshold(float threshold);
     /// Set linear velocity damping factor.
-    /// @property
     void SetLinearDamping(float damping);
     /// Set angular velocity.
-    /// @property
     void SetAngularVelocity(const Vector3& velocity);
     /// Set angular degrees of freedom. Use 1 to enable an axis or 0 to disable. Default is all axes enabled (1, 1, 1).
-    /// @property
     void SetAngularFactor(const Vector3& factor);
     /// Set angular velocity deactivation threshold.
-    /// @property
     void SetAngularRestThreshold(float threshold);
     /// Set angular velocity damping factor.
-    /// @property
     void SetAngularDamping(float damping);
     /// Set friction coefficient.
-    /// @property
     void SetFriction(float friction);
     /// Set anisotropic friction.
-    /// @property
     void SetAnisotropicFriction(const Vector3& friction);
     /// Set rolling friction coefficient.
-    /// @property
     void SetRollingFriction(float friction);
     /// Set restitution coefficient.
-    /// @property
     void SetRestitution(float restitution);
     /// Set contact processing threshold.
-    /// @property
     void SetContactProcessingThreshold(float threshold);
     /// Set continuous collision detection swept sphere radius.
-    /// @property
     void SetCcdRadius(float radius);
     /// Set continuous collision detection motion-per-simulation-step threshold. 0 disables, which is the default.
-    /// @property
     void SetCcdMotionThreshold(float threshold);
     /// Set whether gravity is applied to rigid body.
-    /// @property
     void SetUseGravity(bool enable);
     /// Set gravity override. If zero, uses physics world's gravity.
-    /// @property
     void SetGravityOverride(const Vector3& gravity);
     /// Set rigid body kinematic mode. In kinematic mode forces are not applied to the rigid body.
-    /// @property
     void SetKinematic(bool enable);
     /// Set rigid body trigger mode. In trigger mode collisions are reported but do not apply forces.
-    /// @property
     void SetTrigger(bool enable);
     /// Set collision layer.
-    /// @property
     void SetCollisionLayer(unsigned layer);
     /// Set collision mask.
-    /// @property
     void SetCollisionMask(unsigned mask);
     /// Set collision group and mask.
     void SetCollisionLayerAndMask(unsigned layer, unsigned mask);
     /// Set collision event signaling mode. Default is to signal when rigid bodies are active.
-    /// @property
     void SetCollisionEventMode(CollisionEventMode mode);
     /// Apply force to center of mass.
     void ApplyForce(const Vector3& force);
@@ -171,97 +146,70 @@ public:
     btCompoundShape* GetCompoundShape() const { return compoundShape_.get(); }
 
     /// Return mass.
-    /// @property
     float GetMass() const { return mass_; }
 
     /// Return rigid body position in world space.
-    /// @property
     Vector3 GetPosition() const;
     /// Return rigid body rotation in world space.
-    /// @property
     Quaternion GetRotation() const;
     /// Return linear velocity.
-    /// @property
     Vector3 GetLinearVelocity() const;
     /// Return linear degrees of freedom.
-    /// @property
     Vector3 GetLinearFactor() const;
     /// Return linear velocity at local point.
     Vector3 GetVelocityAtPoint(const Vector3& position) const;
     /// Return linear velocity deactivation threshold.
-    /// @property
     float GetLinearRestThreshold() const;
     /// Return linear velocity damping factor.
-    /// @property
     float GetLinearDamping() const;
     /// Return angular velocity.
-    /// @property
     Vector3 GetAngularVelocity() const;
     /// Return angular degrees of freedom.
-    /// @property
     Vector3 GetAngularFactor() const;
     /// Return angular velocity deactivation threshold.
-    /// @property
     float GetAngularRestThreshold() const;
     /// Return angular velocity damping factor.
-    /// @property
     float GetAngularDamping() const;
     /// Return friction coefficient.
-    /// @property
     float GetFriction() const;
     /// Return anisotropic friction.
-    /// @property
     Vector3 GetAnisotropicFriction() const;
     /// Return rolling friction coefficient.
-    /// @property
     float GetRollingFriction() const;
     /// Return restitution coefficient.
-    /// @property
     float GetRestitution() const;
     /// Return contact processing threshold.
-    /// @property
     float GetContactProcessingThreshold() const;
     /// Return continuous collision detection swept sphere radius.
-    /// @property
     float GetCcdRadius() const;
     /// Return continuous collision detection motion-per-simulation-step threshold.
-    /// @property
     float GetCcdMotionThreshold() const;
 
     /// Return whether rigid body uses gravity.
-    /// @property
     bool GetUseGravity() const { return useGravity_; }
 
     /// Return gravity override. If zero (default), uses the physics world's gravity.
-    /// @property
     const Vector3& GetGravityOverride() const { return gravityOverride_; }
 
     /// Return center of mass offset.
-    /// @property
     const Vector3& GetCenterOfMass() const { return centerOfMass_; }
 
     /// Return kinematic mode flag.
-    /// @property
     bool IsKinematic() const { return kinematic_; }
 
     /// Return whether this RigidBody is acting as a trigger.
-    /// @property
     bool IsTrigger() const { return trigger_; }
 
     /// Return whether rigid body is active (not sleeping).
-    /// @property
     bool IsActive() const;
 
     /// Return collision layer.
-    /// @property
     unsigned GetCollisionLayer() const { return collisionLayer_; }
 
     /// Return collision mask.
-    /// @property
     unsigned GetCollisionMask() const { return collisionMask_; }
 
     /// Return collision event signaling mode.
-    /// @property
     CollisionEventMode GetCollisionEventMode() const { return collisionEventMode_; }
 
     /// Return colliding rigid bodies from the last simulation step. Only returns collisions that were sent as events (depends on collision event mode) and excludes e.g. static-static collisions.

--- a/source/dviglo/physics_2d/collision_box_2d.h
+++ b/source/dviglo/physics_2d/collision_box_2d.h
@@ -24,29 +24,23 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set size.
-    /// @property
     void SetSize(const Vector2& size);
     /// Set size.
     void SetSize(float width, float height);
     /// Set center.
-    /// @property
     void SetCenter(const Vector2& center);
     /// Set center.
     void SetCenter(float x, float y);
     /// Set angle.
-    /// @property
     void SetAngle(float angle);
 
     /// Return size.
-    /// @property
     const Vector2& GetSize() const { return size_; }
 
     /// Return center.
-    /// @property
     const Vector2& GetCenter() const { return center_; }
 
     /// Return angle.
-    /// @property
     float GetAngle() const { return angle_; }
 
 private:

--- a/source/dviglo/physics_2d/collision_chain_2d.h
+++ b/source/dviglo/physics_2d/collision_chain_2d.h
@@ -25,19 +25,15 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set loop.
-    /// @property
     void SetLoop(bool loop);
 
     /// Return loop.
-    /// @property
     bool GetLoop() const { return loop_; }
 
     /// Set vertex count.
-    /// @property
     void SetVertexCount(i32 count);
 
     /// Return vertex count.
-    /// @property
     i32 GetVertexCount() const { return vertices_.Size(); }
 
     /// Set vertex.

--- a/source/dviglo/physics_2d/collision_circle_2d.h
+++ b/source/dviglo/physics_2d/collision_circle_2d.h
@@ -24,20 +24,16 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set radius.
-    /// @property
     void SetRadius(float radius);
     /// Set center.
-    /// @property
     void SetCenter(const Vector2& center);
     /// Set center.
     void SetCenter(float x, float y);
 
     /// Return radius.
-    /// @property
     float GetRadius() const { return radius_; }
 
     /// Return center.
-    /// @property
     const Vector2& GetCenter() const { return center_; }
 
 private:

--- a/source/dviglo/physics_2d/collision_edge_2d.h
+++ b/source/dviglo/physics_2d/collision_edge_2d.h
@@ -24,20 +24,16 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set vertex 1.
-    /// @property
     void SetVertex1(const Vector2& vertex);
     /// Set vertex 2.
-    /// @property
     void SetVertex2(const Vector2& vertex);
     /// Set vertices.
     void SetVertices(const Vector2& vertex1, const Vector2& vertex2);
 
     /// Return vertex 1.
-    /// @property
     const Vector2& GetVertex1() const { return vertex1_; }
 
     /// Return vertex 2.
-    /// @property
     const Vector2& GetVertex2() const { return vertex2_; }
 
 private:

--- a/source/dviglo/physics_2d/collision_polygon_2d.h
+++ b/source/dviglo/physics_2d/collision_polygon_2d.h
@@ -24,7 +24,6 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set vertex count.
-    /// @property
     void SetVertexCount(i32 count);
     /// Set vertex.
     void SetVertex(i32 index, const Vector2& vertex);
@@ -32,7 +31,6 @@ public:
     void SetVertices(const Vector<Vector2>& vertices);
 
     /// Return vertex count.
-    /// @property
     i32 GetVertexCount() const { return vertices_.Size(); }
 
     /// Return vertex.

--- a/source/dviglo/physics_2d/collision_shape_2d.h
+++ b/source/dviglo/physics_2d/collision_shape_2d.h
@@ -31,25 +31,18 @@ public:
     void OnSetEnabled() override;
 
     /// Set trigger.
-    /// @property
     void SetTrigger(bool trigger);
     /// Set filter category bits.
-    /// @property
     void SetCategoryBits(int categoryBits);
     /// Set filter mask bits.
-    /// @property
     void SetMaskBits(int maskBits);
     /// Set filter group index.
-    /// @property
     void SetGroupIndex(int groupIndex);
     /// Set density.
-    /// @property
     void SetDensity(float density);
     /// Set friction.
-    /// @property
     void SetFriction(float friction);
     /// Set restitution.
-    /// @property
     void SetRestitution(float restitution);
 
     /// Create fixture.
@@ -58,41 +51,31 @@ public:
     void ReleaseFixture();
 
     /// Return trigger.
-    /// @property
     bool IsTrigger() const { return fixtureDef_.isSensor; }
 
     /// Return filter category bits.
-    /// @property
     int GetCategoryBits() const { return fixtureDef_.filter.categoryBits; }
 
     /// Return filter mask bits.
-    /// @property
     int GetMaskBits() const { return fixtureDef_.filter.maskBits; }
 
     /// Return filter group index.
-    /// @property
     int GetGroupIndex() const { return fixtureDef_.filter.groupIndex; }
 
     /// Return density.
-    /// @property
     float GetDensity() const { return fixtureDef_.density; }
 
     /// Return friction.
-    /// @property
     float GetFriction() const { return fixtureDef_.friction; }
 
     /// Return restitution.
-    /// @property
     float GetRestitution() const { return fixtureDef_.restitution; }
 
     /// Return mass.
-    /// @property
     float GetMass() const;
     /// Return inertia.
-    /// @property
     float GetInertia() const;
     /// Return mass center.
-    /// @property
     Vector2 GetMassCenter() const;
 
     /// Return fixture.

--- a/source/dviglo/physics_2d/constraint_2d.h
+++ b/source/dviglo/physics_2d/constraint_2d.h
@@ -38,24 +38,19 @@ public:
     void ReleaseJoint();
 
     /// Set other rigid body.
-    /// @property
     void SetOtherBody(RigidBody2D* body);
     /// Set collide connected.
-    /// @property
     void SetCollideConnected(bool collideConnected);
     /// Set attached constriant (for gear).
     void SetAttachedConstraint(Constraint2D* constraint);
 
     /// Return owner body.
-    /// @property
     RigidBody2D* GetOwnerBody() const { return ownerBody_; }
 
     /// Return other body.
-    /// @property
     RigidBody2D* GetOtherBody() const { return otherBody_; }
 
     /// Return collide connected.
-    /// @property
     bool GetCollideConnected() const { return collideConnected_; }
 
     /// Return attached constraint (for gear).

--- a/source/dviglo/physics_2d/constraint_distance_2d.h
+++ b/source/dviglo/physics_2d/constraint_distance_2d.h
@@ -26,59 +26,45 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set owner body anchor.
-    /// @property
     void SetOwnerBodyAnchor(const Vector2& anchor);
 
     /// Return owner body anchor.
-    /// @property
     const Vector2& GetOwnerBodyAnchor() const { return ownerBodyAnchor_; }
 
     /// Set other body anchor.
-    /// @property
     void SetOtherBodyAnchor(const Vector2& anchor);
 
     /// Return other body anchor.
-    /// @property
     const Vector2& GetOtherBodyAnchor() const { return otherBodyAnchor_; }
 
     /// Set linear stiffness in N/m.
-    /// @property
     void SetStiffness(float stiffness);
 
     /// Return linear stiffness in N/m.
-    /// @property
     float GetStiffness() const { return jointDef_.stiffness; }
 
     /// Set linear damping in N*s/m.
-    /// @property
     void SetDamping(float damping);
 
     /// Return linear damping in N*s/m.
-    /// @property
     float GetDamping() const { return jointDef_.damping; }
 
     /// Set length.
-    /// @property
     void SetLength(float length);
 
     /// Return length.
-    /// @property
     float GetLength() const { return jointDef_.length; }
 
     /// Set min length.
-    /// @property
     void SetMinLength(float minLength);
 
     /// Return min length.
-    /// @property
     float GetMinLength() const { return jointDef_.minLength; }
 
     /// Set max length.
-    /// @property
     void SetMaxLength(float maxLength);
 
     /// Return max length.
-    /// @property
     float GetMaxLength() const { return jointDef_.maxLength; }
 
     /// Calc and set stiffness and damping. Must be used after set owner and other bodies.

--- a/source/dviglo/physics_2d/constraint_friction_2d.h
+++ b/source/dviglo/physics_2d/constraint_friction_2d.h
@@ -24,25 +24,19 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set anchor.
-    /// @property
     void SetAnchor(const Vector2& anchor);
     /// Set max force.
-    /// @property
     void SetMaxForce(float maxForce);
     /// Set max torque.
-    /// @property
     void SetMaxTorque(float maxTorque);
 
     /// Return anchor.
-    /// @property
     const Vector2& GetAnchor() const { return anchor_; }
 
     /// Set max force.
-    /// @property
     float GetMaxForce() const { return jointDef_.maxForce; }
 
     /// Set max torque.
-    /// @property
     float GetMaxTorque() const { return jointDef_.maxTorque; }
 
 private:

--- a/source/dviglo/physics_2d/constraint_gear_2d.h
+++ b/source/dviglo/physics_2d/constraint_gear_2d.h
@@ -24,25 +24,19 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set owner constraint.
-    /// @property
     void SetOwnerConstraint(Constraint2D* constraint);
     /// Set other constraint.
-    /// @property
     void SetOtherConstraint(Constraint2D* constraint);
     /// Set ratio.
-    /// @property
     void SetRatio(float ratio);
 
     /// Return owner constraint.
-    /// @property
     Constraint2D* GetOwnerConstraint() const { return ownerConstraint_; }
 
     /// Return other constraint.
-    /// @property
     Constraint2D* GetOtherConstraint() const { return otherConstraint_; }
 
     /// Return ratio.
-    /// @property
     float GetRatio() const { return jointDef_.ratio; }
 
 private:

--- a/source/dviglo/physics_2d/constraint_motor_2d.h
+++ b/source/dviglo/physics_2d/constraint_motor_2d.h
@@ -24,39 +24,29 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set linear offset.
-    /// @property
     void SetLinearOffset(const Vector2& linearOffset);
     /// Set angular offset.
-    /// @property
     void SetAngularOffset(float angularOffset);
     /// Set max force.
-    /// @property
     void SetMaxForce(float maxForce);
     /// Set max torque.
-    /// @property
     void SetMaxTorque(float maxTorque);
     /// Set correction factor.
-    /// @property
     void SetCorrectionFactor(float correctionFactor);
 
     /// Return linear offset.
-    /// @property
     const Vector2& GetLinearOffset() const { return linearOffset_; }
 
     /// Return angular offset.
-    /// @property
     float GetAngularOffset() const { return jointDef_.angularOffset; }
 
     /// Return max force.
-    /// @property
     float GetMaxForce() const { return jointDef_.maxForce; }
 
     /// Return max torque.
-    /// @property
     float GetMaxTorque() const { return jointDef_.maxTorque; }
 
     /// Return correction factor.
-    /// @property
     float GetCorrectionFactor() const { return jointDef_.correctionFactor; }
 
 private:

--- a/source/dviglo/physics_2d/constraint_mouse_2d.h
+++ b/source/dviglo/physics_2d/constraint_mouse_2d.h
@@ -26,35 +26,27 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set target.
-    /// @property
     void SetTarget(const Vector2& target);
 
     /// Return target.
-    /// @property
     const Vector2& GetTarget() const { return target_; }
 
     /// Set max force.
-    /// @property
     void SetMaxForce(float maxForce);
 
     /// Return max force.
-    /// @property
     float GetMaxForce() const { return jointDef_.maxForce; }
 
     /// Set linear stiffness in N/m.
-    /// @property
     void SetStiffness(float stiffness);
 
     /// Return linear stiffness in N/m.
-    /// @property
     float GetStiffness() const { return jointDef_.stiffness; }
 
     /// Set linear damping in N*s/m.
-    /// @property
     void SetDamping(float damping);
 
     /// Return linear damping in N*s/m.
-    /// @property
     float GetDamping() const { return jointDef_.damping; }
 
     /// Calc and set stiffness and damping. Must be used after set owner and other bodies.

--- a/source/dviglo/physics_2d/constraint_prismatic_2d.h
+++ b/source/dviglo/physics_2d/constraint_prismatic_2d.h
@@ -24,60 +24,44 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set anchor.
-    /// @property
     void SetAnchor(const Vector2& anchor);
     /// Set axis.
-    /// @property
     void SetAxis(const Vector2& axis);
     /// Set enable limit.
-    /// @property
     void SetEnableLimit(bool enableLimit);
     /// Set lower translation.
-    /// @property
     void SetLowerTranslation(float lowerTranslation);
     /// Set upper translation.
-    /// @property
     void SetUpperTranslation(float upperTranslation);
     /// Set enable motor.
-    /// @property
     void SetEnableMotor(bool enableMotor);
     /// Set maxmotor force.
-    /// @property
     void SetMaxMotorForce(float maxMotorForce);
     /// Set motor speed.
-    /// @property
     void SetMotorSpeed(float motorSpeed);
 
     /// Return anchor.
-    /// @property
     const Vector2& GetAnchor() const { return anchor_; }
 
     /// Return axis.
-    /// @property
     const Vector2& GetAxis() const { return axis_; }
 
     /// Return enable limit.
-    /// @property
     bool GetEnableLimit() const { return jointDef_.enableLimit; }
 
     /// Return lower translation.
-    /// @property
     float GetLowerTranslation() const { return jointDef_.lowerTranslation; }
 
     /// Return upper translation.
-    /// @property
     float GetUpperTranslation() const { return jointDef_.upperTranslation; }
 
     /// Return enable motor.
-    /// @property
     bool GetEnableMotor() const { return jointDef_.enableMotor; }
 
     /// Return maxmotor force.
-    /// @property
     float GetMaxMotorForce() const { return jointDef_.maxMotorForce; }
 
     /// Return motor speed.
-    /// @property
     float GetMotorSpeed() const { return jointDef_.motorSpeed; }
 
 private:

--- a/source/dviglo/physics_2d/constraint_pulley_2d.h
+++ b/source/dviglo/physics_2d/constraint_pulley_2d.h
@@ -24,39 +24,29 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set other body ground anchor point.
-    /// @property
     void SetOwnerBodyGroundAnchor(const Vector2& groundAnchor);
     /// Set other body ground anchor point.
-    /// @property
     void SetOtherBodyGroundAnchor(const Vector2& groundAnchor);
     /// Set owner body anchor point.
-    /// @property
     void SetOwnerBodyAnchor(const Vector2& anchor);
     /// Set other body anchor point.
-    /// @property
     void SetOtherBodyAnchor(const Vector2& anchor);
     /// Set ratio.
-    /// @property
     void SetRatio(float ratio);
 
     /// Return owner body ground anchor.
-    /// @property
     const Vector2& GetOwnerBodyGroundAnchor() const { return ownerBodyGroundAnchor_; }
 
     /// return other body ground anchor.
-    /// @property
     const Vector2& GetOtherBodyGroundAnchor() const { return otherBodyGroundAnchor_; }
 
     /// Return owner body anchor.
-    /// @property
     const Vector2& GetOwnerBodyAnchor() const { return ownerBodyAnchor_; }
 
     /// Return other body anchor.
-    /// @property
     const Vector2& GetOtherBodyAnchor() const { return otherBodyAnchor_; }
 
     /// Return ratio.
-    /// @property
     float GetRatio() const { return jointDef_.ratio; }
 
 

--- a/source/dviglo/physics_2d/constraint_revolute_2d.h
+++ b/source/dviglo/physics_2d/constraint_revolute_2d.h
@@ -24,53 +24,39 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set anchor.
-    /// @property
     void SetAnchor(const Vector2& anchor);
     /// Set enable limit.
-    /// @property
     void SetEnableLimit(bool enableLimit);
     /// Set lower angle.
-    /// @property
     void SetLowerAngle(float lowerAngle);
     /// Set upper angle.
-    /// @property
     void SetUpperAngle(float upperAngle);
     /// Set enable motor.
-    /// @property
     void SetEnableMotor(bool enableMotor);
     /// Set motor speed.
-    /// @property
     void SetMotorSpeed(float motorSpeed);
     /// Set max motor torque.
-    /// @property
     void SetMaxMotorTorque(float maxMotorTorque);
 
     /// Return anchor.
-    /// @property
     const Vector2& GetAnchor() const { return anchor_; }
 
     /// Return enable limit.
-    /// @property
     bool GetEnableLimit() const { return jointDef_.enableLimit; }
 
     /// Return lower angle.
-    /// @property
     float GetLowerAngle() const { return jointDef_.lowerAngle; }
 
     /// Return upper angle.
-    /// @property
     float GetUpperAngle() const { return jointDef_.upperAngle; }
 
     /// Return enable motor.
-    /// @property
     bool GetEnableMotor() const { return jointDef_.enableMotor; }
 
     /// Return motor speed.
-    /// @property
     float GetMotorSpeed() const { return jointDef_.motorSpeed; }
 
     /// Return max motor torque.
-    /// @property
     float GetMaxMotorTorque() const { return jointDef_.maxMotorTorque; }
 
 private:

--- a/source/dviglo/physics_2d/constraint_weld_2d.h
+++ b/source/dviglo/physics_2d/constraint_weld_2d.h
@@ -26,27 +26,21 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set anchor.
-    /// @property
     void SetAnchor(const Vector2& anchor);
 
     /// Return anchor.
-    /// @property
     const Vector2& GetAnchor() const { return anchor_; }
 
     /// Set linear stiffness in N/m.
-    /// @property
     void SetStiffness(float stiffness);
 
     /// Return linear stiffness in N/m.
-    /// @property
     float GetStiffness() const { return jointDef_.stiffness; }
 
     /// Set linear damping in N*s/m.
-    /// @property
     void SetDamping(float damping);
 
     /// Return linear damping in N*s/m.
-    /// @property
     float GetDamping() const { return jointDef_.damping; }
 
     /// Calc and set stiffness and damping. Must be used after set owner and other bodies.

--- a/source/dviglo/physics_2d/constraint_wheel_2d.h
+++ b/source/dviglo/physics_2d/constraint_wheel_2d.h
@@ -26,83 +26,63 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set anchor.
-    /// @property
     void SetAnchor(const Vector2& anchor);
 
     /// Return anchor.
-    /// @property
     const Vector2& GetAnchor() const { return anchor_; }
 
     /// Set axis.
-    /// @property
     void SetAxis(const Vector2& axis);
 
     /// Return axis.
-    /// @property
     const Vector2& GetAxis() const { return axis_; }
 
     /// Set enable motor.
-    /// @property
     void SetEnableMotor(bool enableMotor);
 
     /// Return enable motor.
-    /// @property
     bool GetEnableMotor() const { return jointDef_.enableMotor; }
 
     /// Set max motor torque.
-    /// @property
     void SetMaxMotorTorque(float maxMotorTorque);
 
     /// Return maxMotor torque.
-    /// @property
     float GetMaxMotorTorque() const { return jointDef_.maxMotorTorque; }
 
     /// Set motor speed.
-    /// @property
     void SetMotorSpeed(float motorSpeed);
 
     /// Return motor speed.
-    /// @property
     float GetMotorSpeed() const { return jointDef_.motorSpeed; }
 
     /// Set linear stiffness in N/m.
-    /// @property
     void SetStiffness(float stiffness);
 
     /// Return linear stiffness in N/m.
-    /// @property
     float GetStiffness() const { return jointDef_.stiffness; }
 
     /// Set linear damping in N*s/m.
-    /// @property
     void SetDamping(float damping);
 
     /// Return linear damping in N*s/m.
-    /// @property
     float GetDamping() const { return jointDef_.damping; }
 
     /// Set enable limit.
-    /// @property
     void SetEnableLimit(bool enableLimit);
 
     /// Return enable limit.
-    /// @property
     bool GetEnableLimit()  const { return jointDef_.enableLimit; }
 
     /// Set lower translation.
-    /// @property
     void SetLowerTranslation(float lowerTranslation);
 
     /// Return lower translation.
-    /// @property
     float GetLowerTranslation() const { return jointDef_.lowerTranslation; }
 
     /// Set upper translation.
-    /// @property
     void SetUpperTranslation(float upperTranslation);
 
     /// Return upper translation.
-    /// @property
     float GetUpperTranslation() const { return jointDef_.upperTranslation; }
 
     /// Calc and set stiffness and damping. Must be used after set owner and other bodies.

--- a/source/dviglo/physics_2d/physics_world_2d.h
+++ b/source/dviglo/physics_2d/physics_world_2d.h
@@ -96,46 +96,32 @@ public:
     /// Add debug geometry to the debug renderer.
     void DrawDebugGeometry();
     /// Enable or disable automatic physics simulation during scene update. Enabled by default.
-    /// @property
     void SetUpdateEnabled(bool enable);
     /// Set draw shape.
-    /// @property
     void SetDrawShape(bool drawShape);
     /// Set draw joint.
-    /// @property
     void SetDrawJoint(bool drawJoint);
     /// Set draw aabb.
-    /// @property
     void SetDrawAabb(bool drawAabb);
     /// Set draw pair.
-    /// @property
     void SetDrawPair(bool drawPair);
     /// Set draw center of mass.
-    /// @property
     void SetDrawCenterOfMass(bool drawCenterOfMass);
     /// Set allow sleeping.
-    /// @property
     void SetAllowSleeping(bool enable);
     /// Set warm starting.
-    /// @property
     void SetWarmStarting(bool enable);
     /// Set continuous physics.
-    /// @property
     void SetContinuousPhysics(bool enable);
     /// Set sub stepping.
-    /// @property
     void SetSubStepping(bool enable);
     /// Set gravity.
-    /// @property
     void SetGravity(const Vector2& gravity);
     /// Set auto clear forces.
-    /// @property
     void SetAutoClearForces(bool enable);
     /// Set velocity iterations.
-    /// @property
     void SetVelocityIterations(int velocityIterations);
     /// Set position iterations.
-    /// @property
     void SetPositionIterations(int positionIterations);
     /// Add rigid body.
     void AddRigidBody(RigidBody2D* rigidBody);
@@ -158,55 +144,41 @@ public:
     void GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, u16 collisionMask = M_U16_MASK_ALL_BITS);
 
     /// Return whether physics world will automatically simulate during scene update.
-    /// @property
     bool IsUpdateEnabled() const { return updateEnabled_; }
 
     /// Return draw shape.
-    /// @property
     bool GetDrawShape() const { return (m_drawFlags & e_shapeBit) != 0; }
 
     /// Return draw joint.
-    /// @property
     bool GetDrawJoint() const { return (m_drawFlags & e_jointBit) != 0; }
 
     /// Return draw aabb.
-    /// @property
     bool GetDrawAabb() const { return (m_drawFlags & e_aabbBit) != 0; }
 
     /// Return draw pair.
-    /// @property
     bool GetDrawPair() const { return (m_drawFlags & e_pairBit) != 0; }
 
     /// Return draw center of mass.
-    /// @property
     bool GetDrawCenterOfMass() const { return (m_drawFlags & e_centerOfMassBit) != 0; }
 
     /// Return allow sleeping.
-    /// @property
     bool GetAllowSleeping() const;
     /// Return warm starting.
-    /// @property
     bool GetWarmStarting() const;
     /// Return continuous physics.
-    /// @property
     bool GetContinuousPhysics() const;
     /// Return sub stepping.
-    /// @property
     bool GetSubStepping() const;
     /// Return auto clear forces.
-    /// @property
     bool GetAutoClearForces() const;
 
     /// Return gravity.
-    /// @property
     const Vector2& GetGravity() const { return gravity_; }
 
     /// Return velocity iterations.
-    /// @property
     int GetVelocityIterations() const { return velocityIterations_; }
 
     /// Return position iterations.
-    /// @property
     int GetPositionIterations() const { return positionIterations_; }
 
     /// Return the Box2D physics world.

--- a/source/dviglo/physics_2d/rigid_body_2d.h
+++ b/source/dviglo/physics_2d/rigid_body_2d.h
@@ -43,43 +43,30 @@ public:
     void OnSetEnabled() override;
 
     /// Set body type.
-    /// @property
     void SetBodyType(BodyType2D type);
     /// Set mass.
-    /// @property
     void SetMass(float mass);
     /// Set inertia.
-    /// @property
     void SetInertia(float inertia);
     /// Set mass center.
-    /// @property
     void SetMassCenter(const Vector2& center);
     /// Set whether to automatically calculate mass and inertia from collision shapes. Default true.
-    /// @property
     void SetUseFixtureMass(bool useFixtureMass);
     /// Set linear damping.
-    /// @property
     void SetLinearDamping(float linearDamping);
     /// Set angular damping.
-    /// @property
     void SetAngularDamping(float angularDamping);
     /// Set allow sleep.
-    /// @property
     void SetAllowSleep(bool allowSleep);
     /// Set fixed rotation.
-    /// @property
     void SetFixedRotation(bool fixedRotation);
     /// Set bullet mode.
-    /// @property
     void SetBullet(bool bullet);
     /// Set gravity scale.
-    /// @property
     void SetGravityScale(float gravityScale);
     /// Set awake.
-    /// @property
     void SetAwake(bool awake);
     /// Set linear velocity.
-    /// @property
     void SetLinearVelocity(const Vector2& linearVelocity);
     /// Set angular velocity.
     void SetAngularVelocity(float angularVelocity);
@@ -115,52 +102,39 @@ public:
     void RemoveConstraint2D(Constraint2D* constraint);
 
     /// Return body type.
-    /// @property
     BodyType2D GetBodyType() const { return body_ ? (BodyType2D)body_->GetType() : (BodyType2D)bodyDef_.type; }
 
     /// Return mass.
-    /// @property
     float GetMass() const;
     /// Return inertia.
-    /// @property
     float GetInertia() const;
     /// Return mass center.
-    /// @property
     Vector2 GetMassCenter() const;
 
     /// Return whether to calculate mass and inertia from collision shapes automatically.
-    /// @property
     bool GetUseFixtureMass() const { return useFixtureMass_; }
 
     /// Return linear damping.
-    /// @property
     float GetLinearDamping() const { return body_ ? body_->GetLinearDamping() : bodyDef_.linearDamping; }
 
     /// Return angular damping.
-    /// @property
     float GetAngularDamping() const { return body_ ? body_->GetAngularDamping() : bodyDef_.angularDamping; }
 
     /// Return allow sleep.
-    /// @property
     bool IsAllowSleep() const { return body_ ? body_->IsSleepingAllowed() : bodyDef_.allowSleep; }
 
     /// Return fixed rotation.
-    /// @property
     bool IsFixedRotation() const { return body_ ? body_->IsFixedRotation() : bodyDef_.fixedRotation; }
 
     /// Return bullet mode.
-    /// @property
     bool IsBullet() const { return body_ ? body_->IsBullet() : bodyDef_.bullet; }
 
     /// Return gravity scale.
-    /// @property
     float GetGravityScale() const { return body_ ? body_->GetGravityScale() : bodyDef_.gravityScale; }
 
     /// Return awake.
-    /// @property
     bool IsAwake() const;
     /// Return linear velocity.
-    /// @property
     Vector2 GetLinearVelocity() const;
     /// Return angular velocity.
     float GetAngularVelocity() const;

--- a/source/dviglo/resource/image.h
+++ b/source/dviglo/resource/image.h
@@ -119,13 +119,10 @@ public:
     /// Save in WebP format with minimum (fastest) or specified compression. Return true if successful. Fails always if WebP support is not compiled in.
     bool SaveWEBP(const String& fileName, float compression = 0.0f) const;
     /// Whether this texture is detected as a cubemap, only relevant for DDS.
-    /// @property
     bool IsCubemap() const { return cubemap_; }
     /// Whether this texture has been detected as a volume, only relevant for DDS.
-    /// @property
     bool IsArray() const { return array_; }
     /// Whether this texture is in sRGB, only relevant for DDS.
-    /// @property
     bool IsSRGB() const { return sRGB_; }
 
     /// Return a 2D pixel color.
@@ -142,34 +139,27 @@ public:
     Color GetPixelTrilinear(float x, float y, float z) const;
 
     /// Return width.
-    /// @property
     int GetWidth() const { return width_; }
 
     /// Return height.
-    /// @property
     int GetHeight() const { return height_; }
 
     /// Return depth.
-    /// @property
     int GetDepth() const { return depth_; }
 
     /// Return number of color components.
-    /// @property
     unsigned GetComponents() const { return components_; }
 
     /// Return pixel data.
     unsigned char* GetData() const { return data_; }
 
     /// Return whether is compressed.
-    /// @property
     bool IsCompressed() const { return compressedFormat_ != CF_NONE; }
 
     /// Return compressed format.
-    /// @property
     CompressedFormat GetCompressedFormat() const { return compressedFormat_; }
 
     /// Return number of compressed mip levels. Returns 0 if the image is has not been loaded from a source file containing multiple mip levels.
-    /// @property
     unsigned GetNumCompressedLevels() const { return numCompressedLevels_; }
 
     /// Return next mip level by bilinear filtering. Note that if the image is already 1x1x1, will keep returning an image of that size.
@@ -189,7 +179,6 @@ public:
     /// Precalculate the mip levels. Used by asynchronous texture loading.
     void PrecalculateLevels();
     /// Whether this texture has an alpha channel.
-    /// @property
     bool HasAlphaChannel() const;
     /// Copy contents of the image into the defined rect, scaling if necessary. This image should already be large enough to include the rect. Compressed and 3D images are not supported.
     bool SetSubimage(const Image* image, const IntRect& rect);

--- a/source/dviglo/resource/json_file.h
+++ b/source/dviglo/resource/json_file.h
@@ -37,7 +37,6 @@ public:
     String ToString(const String& indendation = "\t") const;
 
     /// Return root value.
-    /// @property
     JSONValue& GetRoot() { return root_; }
     /// Return root value.
     const JSONValue& GetRoot() const { return root_; }

--- a/source/dviglo/resource/json_value.h
+++ b/source/dviglo/resource/json_value.h
@@ -161,16 +161,12 @@ public:
     JSONValue& operator =(const JSONValue& rhs);
 
     /// Return value type.
-    /// @property
     JSONValueType GetValueType() const;
     /// Return number type.
-    /// @property
     JSONNumberType GetNumberType() const;
     /// Return value type's name.
-    /// @property
     String GetValueTypeName() const;
     /// Return number type's name.
-    /// @property
     String GetNumberTypeName() const;
 
     /// Check is null.
@@ -227,7 +223,6 @@ public:
     /// Resize array.
     void Resize(unsigned newSize);
     /// Return size of array or number of keys in object.
-    /// @property
     unsigned Size() const;
 
     // JSON object functions

--- a/source/dviglo/resource/json_value.h
+++ b/source/dviglo/resource/json_value.h
@@ -170,22 +170,16 @@ public:
     String GetNumberTypeName() const;
 
     /// Check is null.
-    /// @property{get_isNull}
     bool IsNull() const { return GetValueType() == JSON_NULL; }
     /// Check is boolean.
-    /// @property{get_isBool}
     bool IsBool() const { return GetValueType() == JSON_BOOL; }
     /// Check is number.
-    /// @property{get_isNumber}
     bool IsNumber() const { return GetValueType() == JSON_NUMBER; }
     /// Check is string.
-    /// @property{get_isString}
     bool IsString() const { return GetValueType() == JSON_STRING; }
     /// Check is array.
-    /// @property{get_isArray}
     bool IsArray() const { return GetValueType() == JSON_ARRAY; }
     /// Check is object.
-    /// @property{get_isObject}
     bool IsObject() const { return GetValueType() == JSON_OBJECT; }
 
     /// Return boolean value.

--- a/source/dviglo/resource/localization.h
+++ b/source/dviglo/resource/localization.h
@@ -22,17 +22,14 @@ public:
     ~Localization() override;
 
     /// Return the number of languages.
-    /// @property
     int GetNumLanguages() const { return (int)languages_.Size(); }
 
     /// Return the index number of current language. The index is determined by the order of loading.
-    /// @property
     int GetLanguageIndex() const { return languageIndex_; }
 
     /// Return the index number of language. The index is determined by the order of loading.
     int GetLanguageIndex(const String& language);
     /// Return the name of current language.
-    /// @property
     String GetLanguage();
     /// Return the name of language.
     String GetLanguage(int index);

--- a/source/dviglo/resource/resource.h
+++ b/source/dviglo/resource/resource.h
@@ -105,7 +105,6 @@ public:
     explicit ResourceWithMetadata(Context* context) : Resource(context) {}
 
     /// Add new metadata variable or overwrite old value.
-    /// @property{set_metadata}
     void AddMetadata(const String& name, const Variant& value);
     /// Remove metadata variable.
     void RemoveMetadata(const String& name);

--- a/source/dviglo/resource/resource.h
+++ b/source/dviglo/resource/resource.h
@@ -59,7 +59,6 @@ public:
     virtual bool SaveFile(const String& fileName) const;
 
     /// Set name.
-    /// @property
     void SetName(const String& name);
     /// Set memory use in bytes, possibly approximate.
     void SetMemoryUse(i32 size);
@@ -69,18 +68,15 @@ public:
     void SetAsyncLoadState(AsyncLoadState newState);
 
     /// Return name.
-    /// @property
     const String& GetName() const { return name_; }
 
     /// Return name hash.
     StringHash GetNameHash() const { return nameHash_; }
 
     /// Return memory use in bytes, possibly approximate.
-    /// @property
     i32 GetMemoryUse() const { return memoryUse_; }
 
     /// Return time since last use in milliseconds. If referred to elsewhere than in the resource cache, returns always zero.
-    /// @property
     unsigned GetUseTimer();
 
     /// Return the asynchronous loading state.
@@ -116,10 +112,8 @@ public:
     /// Remove all metadata variables.
     void RemoveAllMetadata();
     /// Return metadata variable.
-    /// @property
     const Variant& GetMetadata(const String& name) const;
     /// Return whether the resource has metadata.
-    /// @property
     bool HasMetadata() const;
 
 protected:

--- a/source/dviglo/resource/resource_cache.h
+++ b/source/dviglo/resource/resource_cache.h
@@ -101,21 +101,16 @@ public:
     /// Reload a resource based on filename. Causes also reload of dependent resources if necessary.
     void ReloadResourceWithDependencies(const String& fileName);
     /// Set memory budget for a specific resource type, default 0 is unlimited.
-    /// @property
     void SetMemoryBudget(StringHash type, unsigned long long budget);
     /// Enable or disable automatic reloading of resources as files are modified. Default false.
-    /// @property
     void SetAutoReloadResources(bool enable);
     /// Enable or disable returning resources that failed to load. Default false. This may be useful in editing to not lose resource ref attributes.
-    /// @property
     void SetReturnFailedResources(bool enable) { returnFailedResources_ = enable; }
 
     /// Define whether when getting resources should check package files or directories first. True for packages, false for directories.
-    /// @property
     void SetSearchPackagesFirst(bool value) { searchPackagesFirst_ = value; }
 
     /// Set how many milliseconds maximum per frame to spend on finishing background loaded resources.
-    /// @property
     void SetFinishBackgroundResourcesMs(int ms) { finishBackgroundResourcesMs_ = Max(ms, 1); }
 
     /// Add a resource router object. By default there is none, so the routing process is skipped.
@@ -132,7 +127,6 @@ public:
     /// Background load a resource. An event will be sent when complete. Return true if successfully stored to the load queue, false if eg. already exists. Can be called from outside the main thread.
     bool BackgroundLoadResource(StringHash type, const String& name, bool sendEventOnFailure = true, Resource* caller = nullptr);
     /// Return number of pending background-loaded resources.
-    /// @property
     unsigned GetNumBackgroundLoadResources() const;
     /// Return all loaded resources of a specific type.
     void GetResources(Vector<Resource*>& result, StringHash type) const;
@@ -143,11 +137,9 @@ public:
     const HashMap<StringHash, ResourceGroup>& GetAllResources() const { return resourceGroups_; }
 
     /// Return added resource load directories.
-    /// @property
     const Vector<String>& GetResourceDirs() const { return resourceDirs_; }
 
     /// Return added package files.
-    /// @property
     const Vector<SharedPtr<PackageFile>>& GetPackageFiles() const { return packages_; }
 
     /// Template version of returning a resource by name.
@@ -165,31 +157,24 @@ public:
     /// Return whether a file exists in the resource directories or package files. Does not check manually added in-memory resources.
     bool Exists(const String& name) const;
     /// Return memory budget for a resource type.
-    /// @property
     unsigned long long GetMemoryBudget(StringHash type) const;
     /// Return total memory use for a resource type.
-    /// @property
     unsigned long long GetMemoryUse(StringHash type) const;
     /// Return total memory use for all resources.
-    /// @property
     unsigned long long GetTotalMemoryUse() const;
     /// Return full absolute file name of resource if possible, or empty if not found.
     String GetResourceFileName(const String& name) const;
 
     /// Return whether automatic resource reloading is enabled.
-    /// @property
     bool GetAutoReloadResources() const { return autoReloadResources_; }
 
     /// Return whether resources that failed to load are returned.
-    /// @property
     bool GetReturnFailedResources() const { return returnFailedResources_; }
 
     /// Return whether when getting resources should check package files or directories first.
-    /// @property
     bool GetSearchPackagesFirst() const { return searchPackagesFirst_; }
 
     /// Return how many milliseconds maximum to spend on finishing background loaded resources.
-    /// @property
     int GetFinishBackgroundResourcesMs() const { return finishBackgroundResourcesMs_; }
 
     /// Return a resource router by index.

--- a/source/dviglo/resource/xml_element.h
+++ b/source/dviglo/resource/xml_element.h
@@ -158,7 +158,6 @@ public:
     bool SetMatrix4(const String& name, const Matrix4& value);
 
     /// Return whether does not refer to an element or an XPath node.
-    /// @property{get_isNull}
     bool IsNull() const;
     /// Return whether refers to an element or an XPath node.
     bool NotNull() const;

--- a/source/dviglo/resource/xml_element.h
+++ b/source/dviglo/resource/xml_element.h
@@ -83,7 +83,6 @@ public:
     XPathResultSet SelectPrepared(const XPathQuery& query) const;
 
     /// Set the value for an inner node in the following format <node>value</node>.
-    /// @property
     bool SetValue(const String& value);
     /// Set the value for an inner node in the following format <node>value</node>. Must be used on the <node> element.
     bool SetValue(const char* value);
@@ -162,12 +161,10 @@ public:
     /// @property{get_isNull}
     bool IsNull() const;
     /// Return whether refers to an element or an XPath node.
-    /// @property
     bool NotNull() const;
     /// Return true if refers to an element or an XPath node.
     explicit operator bool() const;
     /// Return element name (or attribute name if it is an attribute only XPath query result).
-    /// @property
     String GetName() const;
     /// Return whether has a child element.
     bool HasChild(const String& name) const;
@@ -182,17 +179,14 @@ public:
     /// Return next sibling element.
     XMLElement GetNext(const char* name) const;
     /// Return parent element.
-    /// @property
     XMLElement GetParent() const;
     /// Return number of attributes.
-    /// @property
     i32 GetNumAttributes() const;
     /// Return whether has an attribute.
     bool HasAttribute(const String& name) const;
     /// Return whether has an attribute.
     bool HasAttribute(const char* name) const;
     /// Return inner value, or empty if missing for nodes like <node>value</node>.
-    /// @property
     String GetValue() const;
     /// Return attribute, or empty if missing.
     String GetAttribute(const String& name = String::EMPTY) const;
@@ -273,7 +267,6 @@ public:
     /// Return a Matrix4 attribute, or zero matrix if missing.
     Matrix4 GetMatrix4(const String& name) const;
     /// Return XML file.
-    /// @property
     XMLFile* GetFile() const;
 
     /// Return pugixml xml_node_struct.
@@ -289,7 +282,6 @@ public:
     i32 GetXPathResultIndex() const { return xpathResultIndex_; }
 
     /// Return next XPath query result. Only valid when this instance of XMLElement is itself one of the query result in the result set.
-    /// @property
     XMLElement NextResult() const;
 
     /// Empty XMLElement.
@@ -327,13 +319,10 @@ public:
     XMLElement operator [](i32 index) const;
     /// Return the first result in the set. Call XMLElement::GetNextResult() to get the subsequent result in the set.
     /// Note: The XPathResultSet return value must be stored in a lhs variable to ensure the underlying xpath_node_set* is still valid while performing XPathResultSet::FirstResult(), XPathResultSet::operator [], and XMLElement::NextResult().
-    /// @property
     XMLElement FirstResult();
     /// Return size of result set.
-    /// @property
     i32 Size() const;
     /// Return whether result set is empty.
-    /// @property
     bool Empty() const;
 
     /// Return pugixml xpath_node_set.
@@ -383,7 +372,6 @@ public:
     XPathResultSet Evaluate(const XMLElement& element) const;
 
     /// Return query string.
-    /// @property
     String GetQuery() const { return queryString_; }
 
     /// Return pugixml xpath_query.

--- a/source/dviglo/scene/animatable.h
+++ b/source/dviglo/scene/animatable.h
@@ -65,13 +65,11 @@ public:
     bool SaveJSON(JSONValue& dest) const override;
 
     /// Set automatic update of animation, default true.
-    /// @property
     void SetAnimationEnabled(bool enable);
     /// Set time position of all attribute animations or an object animation manually. Automatic update should be disabled in this case.
     void SetAnimationTime(float time);
 
     /// Set object animation.
-    /// @property
     void SetObjectAnimation(ObjectAnimation* objectAnimation);
     /// Set attribute animation.
     void SetAttributeAnimation
@@ -88,11 +86,9 @@ public:
     void RemoveAttributeAnimation(const String& name);
 
     /// Return animation enabled.
-    /// @property
     bool GetAnimationEnabled() const { return animationEnabled_; }
 
     /// Return object animation.
-    /// @property
     ObjectAnimation* GetObjectAnimation() const;
     /// Return attribute animation.
     ValueAnimation* GetAttributeAnimation(const String& name) const;

--- a/source/dviglo/scene/component.h
+++ b/source/dviglo/scene/component.h
@@ -59,7 +59,6 @@ public:
     virtual void DrawDebugGeometry(DebugRenderer* debug, bool depthTest);
 
     /// Set enabled/disabled state.
-    /// @property
     void SetEnabled(bool enable);
     /// Remove from the scene node. If no other shared pointer references exist, causes immediate deletion.
     void Remove();
@@ -68,21 +67,17 @@ public:
     /// @property{get_id}
     ComponentId GetID() const { return id_; }
     /// Return whether the component is replicated or local to a scene.
-    /// @property
     bool IsReplicated() const;
 
     /// Return scene node.
-    /// @property
     Node* GetNode() const { return node_; }
 
     /// Return the scene the node belongs to.
     Scene* GetScene() const;
 
     /// Return whether is enabled.
-    /// @property
     bool IsEnabled() const { return enabled_; }
     /// Return whether is effectively enabled (node is also enabled).
-    /// @property
     bool IsEnabledEffective() const;
 
     /// Return component in the same scene node by type. If there are several, returns the first.

--- a/source/dviglo/scene/component.h
+++ b/source/dviglo/scene/component.h
@@ -64,7 +64,6 @@ public:
     void Remove();
 
     /// Return ID.
-    /// @property{get_id}
     ComponentId GetID() const { return id_; }
     /// Return whether the component is replicated or local to a scene.
     bool IsReplicated() const;
@@ -111,7 +110,6 @@ protected:
     /// Handle scene node enabled status changing.
     virtual void OnNodeSetEnabled(Node* node);
     /// Set ID. Called by Scene.
-    /// @property{set_id}
     void SetID(ComponentId id);
     /// Set scene node. Called by Node when creating the component.
     void SetNode(Node* node);

--- a/source/dviglo/scene/node.h
+++ b/source/dviglo/scene/node.h
@@ -102,7 +102,6 @@ public:
     /// Save to a JSON file. Return true if successful.
     bool SaveJSON(Serializer& dest, const String& indentation = "\t") const;
     /// Set name of the scene node. Names are not required to be unique.
-    /// @property
     void SetName(const String& name);
 
     /// Set tags. Old tags are overwritten.
@@ -119,35 +118,28 @@ public:
     void RemoveAllTags();
 
     /// Set position in parent space. If the scene node is on the root level (is child of the scene itself), this is same as world space.
-    /// @property
     void SetPosition(const Vector3& position);
 
     /// Set position in parent space (for Urho2D).
-    /// @property
     void SetPosition2D(const Vector2& position) { SetPosition(Vector3(position)); }
 
     /// Set position in parent space (for Urho2D).
     void SetPosition2D(float x, float y) { SetPosition(Vector3(x, y, 0.0f)); }
 
     /// Set rotation in parent space.
-    /// @property
     void SetRotation(const Quaternion& rotation);
 
     /// Set rotation in parent space (for Urho2D).
-    /// @property
     void SetRotation2D(float rotation) { SetRotation(Quaternion(rotation)); }
 
     /// Set forward direction in parent space. Positive Z axis equals identity rotation.
-    /// @property
     void SetDirection(const Vector3& direction);
     /// Set uniform scale in parent space.
     void SetScale(float scale);
     /// Set scale in parent space.
-    /// @property
     void SetScale(const Vector3& scale);
 
     /// Set scale in parent space (for Urho2D).
-    /// @property
     void SetScale2D(const Vector2& scale) { SetScale(Vector3(scale, 1.0f)); }
 
     /// Set scale in parent space (for Urho2D).
@@ -178,35 +170,28 @@ public:
     }
 
     /// Set position in world space.
-    /// @property
     void SetWorldPosition(const Vector3& position);
 
     /// Set position in world space (for Urho2D).
-    /// @property
     void SetWorldPosition2D(const Vector2& position) { SetWorldPosition(Vector3(position)); }
 
     /// Set position in world space (for Urho2D).
     void SetWorldPosition2D(float x, float y) { SetWorldPosition(Vector3(x, y, 0.0f)); }
 
     /// Set rotation in world space.
-    /// @property
     void SetWorldRotation(const Quaternion& rotation);
 
     /// Set rotation in world space (for Urho2D).
-    /// @property
     void SetWorldRotation2D(float rotation) { SetWorldRotation(Quaternion(rotation)); }
 
     /// Set forward direction in world space.
-    /// @property
     void SetWorldDirection(const Vector3& direction);
     /// Set uniform scale in world space.
     void SetWorldScale(float scale);
     /// Set scale in world space.
-    /// @property
     void SetWorldScale(const Vector3& scale);
 
     /// Set scale in world space (for Urho2D).
-    /// @property
     void SetWorldScale2D(const Vector2& scale) { SetWorldScale(Vector3(scale, 1.0f)); }
 
     /// Set scale in world space (for Urho2D).
@@ -277,7 +262,6 @@ public:
     void Scale2D(const Vector2& scale) { Scale(Vector3(scale, 1.0f)); }
 
     /// Set enabled/disabled state without recursion. Components in a disabled node become effectively disabled regardless of their own enable/disable state.
-    /// @property
     void SetEnabled(bool enable);
     /// Set enabled state on self and child nodes. Nodes' own enabled state is remembered (IsEnabledSelf) and can be restored.
     void SetDeepEnabled(bool enable);
@@ -331,7 +315,6 @@ public:
     /// Remove from the parent node. If no other shared pointer references exist, causes immediate deletion.
     void Remove();
     /// Assign to a new parent scene node. Retains the world transform.
-    /// @property
     void SetParent(Node* parent);
     /// Set a user variable.
     void SetVar(StringHash key, const Variant& value);
@@ -352,40 +335,33 @@ public:
     /// @property{get_id}
     NodeId GetID() const { return id_; }
     /// Return whether the node is replicated or local to a scene.
-    /// @property
     bool IsReplicated() const;
 
     /// Return name.
-    /// @property
     const String& GetName() const { return impl_->name_; }
 
     /// Return name hash.
     StringHash GetNameHash() const { return impl_->nameHash_; }
 
     /// Return all tags.
-    /// @property
     const StringVector& GetTags() const { return impl_->tags_; }
 
     /// Return whether has a specific tag.
     bool HasTag(const String& tag) const;
 
     /// Return parent scene node.
-    /// @property
     Node* GetParent() const { return parent_; }
 
     /// Return scene.
-    /// @property
     Scene* GetScene() const { return scene_; }
 
     /// Return whether is a direct or indirect child of specified node.
     bool IsChildOf(Node* node) const;
 
     /// Return whether is enabled. Disables nodes effectively disable all their components.
-    /// @property
     bool IsEnabled() const { return enabled_; }
 
     /// Return the node's last own enabled state. May be different than the value returned by IsEnabled when SetDeepEnabled has been used.
-    /// @property
     bool IsEnabledSelf() const { return enabledPrev_; }
 
     /// Return owner connection in networking.
@@ -393,47 +369,36 @@ public:
     Connection* GetOwner() const { return impl_->owner_; }
 
     /// Return position in parent space.
-    /// @property
     const Vector3& GetPosition() const { return position_; }
 
     /// Return position in parent space (for Urho2D).
-    /// @property
     Vector2 GetPosition2D() const { return Vector2(position_.x_, position_.y_); }
 
     /// Return rotation in parent space.
-    /// @property
     const Quaternion& GetRotation() const { return rotation_; }
 
     /// Return rotation in parent space (for Urho2D).
-    /// @property
     float GetRotation2D() const { return rotation_.RollAngle(); }
 
     /// Return forward direction in parent space. Positive Z axis equals identity rotation.
-    /// @property
     Vector3 GetDirection() const { return rotation_ * Vector3::FORWARD; }
 
     /// Return up direction in parent space. Positive Y axis equals identity rotation.
-    /// @property
     Vector3 GetUp() const { return rotation_ * Vector3::UP; }
 
     /// Return right direction in parent space. Positive X axis equals identity rotation.
-    /// @property
     Vector3 GetRight() const { return rotation_ * Vector3::RIGHT; }
 
     /// Return scale in parent space.
-    /// @property
     const Vector3& GetScale() const { return scale_; }
 
     /// Return scale in parent space (for Urho2D).
-    /// @property
     Vector2 GetScale2D() const { return Vector2(scale_.x_, scale_.y_); }
 
     /// Return parent space transform matrix.
-    /// @property
     Matrix3x4 GetTransform() const { return Matrix3x4(position_, rotation_, scale_); }
 
     /// Return position in world space.
-    /// @property
     Vector3 GetWorldPosition() const
     {
         if (dirty_)
@@ -443,7 +408,6 @@ public:
     }
 
     /// Return position in world space (for Urho2D).
-    /// @property
     Vector2 GetWorldPosition2D() const
     {
         Vector3 worldPosition = GetWorldPosition();
@@ -451,7 +415,6 @@ public:
     }
 
     /// Return rotation in world space.
-    /// @property
     Quaternion GetWorldRotation() const
     {
         if (dirty_)
@@ -461,14 +424,12 @@ public:
     }
 
     /// Return rotation in world space (for Urho2D).
-    /// @property
     float GetWorldRotation2D() const
     {
         return GetWorldRotation().RollAngle();
     }
 
     /// Return direction in world space.
-    /// @property
     Vector3 GetWorldDirection() const
     {
         if (dirty_)
@@ -478,7 +439,6 @@ public:
     }
 
     /// Return node's up vector in world space.
-    /// @property
     Vector3 GetWorldUp() const
     {
         if (dirty_)
@@ -488,7 +448,6 @@ public:
     }
 
     /// Return node's right vector in world space.
-    /// @property
     Vector3 GetWorldRight() const
     {
         if (dirty_)
@@ -498,7 +457,6 @@ public:
     }
 
     /// Return scale in world space.
-    /// @property
     Vector3 GetWorldScale() const
     {
         if (dirty_)
@@ -508,11 +466,9 @@ public:
     }
 
     /// Return signed scale in world space. Utilized for Urho2D physics.
-    /// @property
     Vector3 GetSignedWorldScale() const;
 
     /// Return scale in world space (for Urho2D).
-    /// @property
     Vector2 GetWorldScale2D() const
     {
         Vector3 worldScale = GetWorldScale();
@@ -520,7 +476,6 @@ public:
     }
 
     /// Return world space transform matrix.
-    /// @property
     const Matrix3x4& GetWorldTransform() const
     {
         if (dirty_)
@@ -575,7 +530,6 @@ public:
     Node* GetChild(StringHash nameHash, bool recursive = false) const;
 
     /// Return number of components.
-    /// @property
     i32 GetNumComponents() const { return components_.Size(); }
 
     /// Return number of non-local components.

--- a/source/dviglo/scene/node.h
+++ b/source/dviglo/scene/node.h
@@ -332,7 +332,6 @@ public:
     template <class T> void RemoveComponents();
 
     /// Return ID.
-    /// @property{get_id}
     NodeId GetID() const { return id_; }
     /// Return whether the node is replicated or local to a scene.
     bool IsReplicated() const;
@@ -573,7 +572,6 @@ public:
     template <class T> bool HasComponent() const;
 
     /// Set ID. Called by Scene.
-    /// @property{set_id}
     void SetID(NodeId id);
     /// Set scene. Called by Scene.
     void SetScene(Scene* scene);

--- a/source/dviglo/scene/object_animation.h
+++ b/source/dviglo/scene/object_animation.h
@@ -51,13 +51,10 @@ public:
     void RemoveAttributeAnimation(ValueAnimation* attributeAnimation);
 
     /// Return attribute animation by name.
-    /// @property{get_attributeAnimations}
     ValueAnimation* GetAttributeAnimation(const String& name) const;
     /// Return attribute animation wrap mode by name.
-    /// @property{get_wrapModes}
     WrapMode GetAttributeAnimationWrapMode(const String& name) const;
     /// Return attribute animation speed by name.
-    /// @property{get_speeds}
     float GetAttributeAnimationSpeed(const String& name) const;
 
     /// Return all attribute animations infos.

--- a/source/dviglo/scene/scene.h
+++ b/source/dviglo/scene/scene.h
@@ -131,22 +131,16 @@ public:
     /// Clear scene completely of either replicated, local or all nodes and components.
     void Clear(bool clearReplicated = true, bool clearLocal = true);
     /// Enable or disable scene update.
-    /// @property
     void SetUpdateEnabled(bool enable);
     /// Set update time scale. 1.0 = real time (default).
-    /// @property
     void SetTimeScale(float scale);
     /// Set elapsed time in seconds. This can be used to prevent inaccuracy in the timer if the scene runs for a long time.
-    /// @property
     void SetElapsedTime(float time);
     /// Set network client motion smoothing constant.
-    /// @property
     void SetSmoothingConstant(float constant);
     /// Set network client motion smoothing snap threshold.
-    /// @property
     void SetSnapThreshold(float threshold);
     /// Set maximum milliseconds per frame to spend on async scene loading.
-    /// @property
     void SetAsyncLoadingMs(int ms);
     /// Add a required package file for networking. To be called on the server.
     void AddRequiredPackageFile(PackageFile* package);
@@ -167,51 +161,39 @@ public:
     bool GetNodesWithTag(Vector<Node*>& dest, const String& tag)  const;
 
     /// Return whether updates are enabled.
-    /// @property
     bool IsUpdateEnabled() const { return updateEnabled_; }
 
     /// Return whether an asynchronous loading operation is in progress.
-    /// @property
     bool IsAsyncLoading() const { return asyncLoading_; }
 
     /// Return asynchronous loading progress between 0.0 and 1.0, or 1.0 if not in progress.
-    /// @property
     float GetAsyncProgress() const;
 
     /// Return the load mode of the current asynchronous loading operation.
-    /// @property
     LoadMode GetAsyncLoadMode() const { return asyncProgress_.mode_; }
 
     /// Return source file name.
-    /// @property
     const String& GetFileName() const { return fileName_; }
 
     /// Return source file checksum.
-    /// @property
     hash32 GetChecksum() const { return checksum_; }
 
     /// Return update time scale.
-    /// @property
     float GetTimeScale() const { return timeScale_; }
 
     /// Return elapsed time in seconds.
-    /// @property
     float GetElapsedTime() const { return elapsedTime_; }
 
     /// Return motion smoothing constant.
-    /// @property
     float GetSmoothingConstant() const { return smoothingConstant_; }
 
     /// Return motion smoothing snap threshold.
-    /// @property
     float GetSnapThreshold() const { return snapThreshold_; }
 
     /// Return maximum milliseconds per frame to spend on async loading.
-    /// @property
     int GetAsyncLoadingMs() const { return asyncLoadingMs_; }
 
     /// Return required package files.
-    /// @property
     const Vector<SharedPtr<PackageFile>>& GetRequiredPackageFiles() const { return requiredPackageFiles_; }
 
     /// Return a node user variable name, or empty if not registered.

--- a/source/dviglo/scene/serializable.h
+++ b/source/dviglo/scene/serializable.h
@@ -77,7 +77,6 @@ public:
     /// Remove instance's default values if they are set previously.
     void RemoveInstanceDefault();
     /// Set temporary flag. Temporary objects will not be saved.
-    /// @property
     void SetTemporary(bool enable);
     /// Enable interception of an attribute from network updates. Intercepted attributes are sent as events instead of applying directly. This can be used to implement client side prediction.
     void SetInterceptNetworkUpdate(const String& attributeName, bool enable);
@@ -105,13 +104,11 @@ public:
     /// Return attribute default value by name. Return empty if not found.
     Variant GetAttributeDefault(const String& name) const;
     /// Return number of attributes.
-    /// @property
     unsigned GetNumAttributes() const;
     /// Return number of network replication attributes.
     unsigned GetNumNetworkAttributes() const;
 
     /// Return whether is temporary.
-    /// @property
     bool IsTemporary() const { return temporary_; }
 
     /// Return whether an attribute's network updates are being intercepted.

--- a/source/dviglo/scene/serializable.h
+++ b/source/dviglo/scene/serializable.h
@@ -66,7 +66,6 @@ public:
     virtual void MarkNetworkUpdate() { }
 
     /// Set attribute by index. Return true if successfully set.
-    /// @property{set_attributes}
     bool SetAttribute(unsigned index, const Variant& value);
     /// Set attribute by name. Return true if successfully set.
     bool SetAttribute(const String& name, const Variant& value);
@@ -94,12 +93,10 @@ public:
     bool ReadLatestDataUpdate(Deserializer& source);
 
     /// Return attribute value by index. Return empty if illegal index.
-    /// @property{get_attributes}
     Variant GetAttribute(unsigned index) const;
     /// Return attribute value by name. Return empty if not found.
     Variant GetAttribute(const String& name) const;
     /// Return attribute default value by index. Return empty if illegal index.
-    /// @property{get_attributeDefaults}
     Variant GetAttributeDefault(unsigned index) const;
     /// Return attribute default value by name. Return empty if not found.
     Variant GetAttributeDefault(const String& name) const;

--- a/source/dviglo/scene/smoothed_transform.h
+++ b/source/dviglo/scene/smoothed_transform.h
@@ -39,35 +39,26 @@ public:
     /// Update smoothing.
     void Update(float constant, float squaredSnapThreshold);
     /// Set target position in parent space.
-    /// @property
     void SetTargetPosition(const Vector3& position);
     /// Set target rotation in parent space.
-    /// @property
     void SetTargetRotation(const Quaternion& rotation);
     /// Set target position in world space.
-    /// @property
     void SetTargetWorldPosition(const Vector3& position);
     /// Set target rotation in world space.
-    /// @property
     void SetTargetWorldRotation(const Quaternion& rotation);
 
     /// Return target position in parent space.
-    /// @property
     const Vector3& GetTargetPosition() const { return targetPosition_; }
 
     /// Return target rotation in parent space.
-    /// @property
     const Quaternion& GetTargetRotation() const { return targetRotation_; }
 
     /// Return target position in world space.
-    /// @property
     Vector3 GetTargetWorldPosition() const;
     /// Return target rotation in world space.
-    /// @property
     Quaternion GetTargetWorldRotation() const;
 
     /// Return whether smoothing is in progress.
-    /// @property
     bool IsInProgress() const { return smoothingMask_ != SMOOTH_NONE; }
 
 protected:

--- a/source/dviglo/scene/spline_path.h
+++ b/source/dviglo/scene/spline_path.h
@@ -79,7 +79,6 @@ public:
     void Reset();
 
     /// Returns whether the movement along the SplinePath is complete.
-    /// @property{get_isFinished}
     bool IsFinished() const { return traveled_ >= 1.0f; }
 
     /// Set Control Point Node IDs attribute.

--- a/source/dviglo/scene/spline_path.h
+++ b/source/dviglo/scene/spline_path.h
@@ -45,36 +45,29 @@ public:
     void ClearControlPoints();
 
     /// Set the Interpolation Mode.
-    /// @property
     void SetInterpolationMode(InterpolationMode interpolationMode);
 
     /// Set the movement Speed.
-    /// @property
     void SetSpeed(float speed) { speed_ = speed; }
 
     /// Set the controlled Node's position on the SplinePath.
     void SetPosition(float factor);
     /// Set the Node to be moved along the SplinePath.
-    /// @property
     void SetControlledNode(Node* controlled);
 
     /// Get the Interpolation Mode.
-    /// @property
     InterpolationMode GetInterpolationMode() const { return spline_.GetInterpolationMode(); }
 
     /// Get the movement Speed.
-    /// @property
     float GetSpeed() const { return speed_; }
 
     /// Get the length of SplinePath.
-    /// @property
     float GetLength() const { return length_; }
 
     /// Get the parent Node's last position on the spline.
     Vector3 GetPosition() const { return GetPoint(traveled_); }
 
     /// Get the controlled Node.
-    /// @property
     Node* GetControlledNode() const { return controlledNode_; }
 
     /// Get a point on the SplinePath from 0.f to 1.f where 0 is the start and 1 is the end.

--- a/source/dviglo/scene/value_animation.h
+++ b/source/dviglo/scene/value_animation.h
@@ -76,13 +76,10 @@ public:
     /// Set owner.
     void SetOwner(void* owner);
     /// Set interpolation method.
-    /// @property
     void SetInterpolationMethod(InterpMethod method);
     /// Set spline tension, should be between 0.0f and 1.0f, but this is not a must.
-    /// @property
     void SetSplineTension(float tension);
     /// Set value type.
-    /// @property
     void SetValueType(VariantType valueType);
 
     /// Set key frame.
@@ -97,15 +94,12 @@ public:
     void* GetOwner() const { return owner_; }
 
     /// Return interpolation method.
-    /// @property
     InterpMethod GetInterpolationMethod() const { return interpolationMethod_; }
 
     /// Return spline tension.
-    /// @property
     float GetSplineTension() const { return splineTension_; }
 
     /// Return value type.
-    /// @property
     VariantType GetValueType() const { return valueType_; }
 
     /// Return begin time.

--- a/source/dviglo/ui/border_image.h
+++ b/source/dviglo/ui/border_image.h
@@ -31,73 +31,55 @@ public:
     void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// Set texture.
-    /// @property
     void SetTexture(Texture* texture);
     /// Set part of texture to use as the image.
-    /// @property
     void SetImageRect(const IntRect& rect);
     /// Use whole texture as the image.
     void SetFullImageRect();
     /// Set border dimensions on the screen.
-    /// @property
     void SetBorder(const IntRect& rect);
     /// Set border dimensions on the image. If zero (default) uses the screen dimensions, resulting in pixel-perfect borders.
-    /// @property
     void SetImageBorder(const IntRect& rect);
     /// Set offset to image rectangle used on hover.
-    /// @property
     void SetHoverOffset(const IntVector2& offset);
     /// Set offset to image rectangle used on hover.
     void SetHoverOffset(int x, int y);
     /// Set offset to image rectangle used when disabled.
-    /// @property
     void SetDisabledOffset(const IntVector2& offset);
     /// Set offset to image rectangle used when disabled.
     void SetDisabledOffset(int x, int y);
     /// Set blend mode.
-    /// @property
     void SetBlendMode(BlendMode mode);
     /// Set tiled mode.
-    /// @property
     void SetTiled(bool enable);
     /// Set material for custom rendering.
-    /// @property
     void SetMaterial(Material* material);
 
     /// Return texture.
-    /// @property
     Texture* GetTexture() const { return texture_; }
 
     /// Return image rectangle.
-    /// @property
     const IntRect& GetImageRect() const { return imageRect_; }
 
     /// Return border screen dimensions.
-    /// @property
     const IntRect& GetBorder() const { return border_; }
 
     /// Return border image dimensions. Zero rect uses border screen dimensions.
-    /// @property
     const IntRect& GetImageBorder() const { return imageBorder_; }
 
     /// Return offset to image rectangle used on hover.
-    /// @property
     const IntVector2& GetHoverOffset() const { return hoverOffset_; }
 
     /// Return offset to image rectangle used when disabled.
-    /// @property
     const IntVector2& GetDisabledOffset() const { return disabledOffset_; }
 
     /// Return blend mode.
-    /// @property
     BlendMode GetBlendMode() const { return blendMode_; }
 
     /// Return whether is tiled.
-    /// @property
     bool IsTiled() const { return tiled_; }
 
     /// Get material used for custom rendering.
-    /// @property
     Material* GetMaterial() const;
 
     /// Set texture attribute.

--- a/source/dviglo/ui/button.h
+++ b/source/dviglo/ui/button.h
@@ -42,42 +42,33 @@ public:
     void OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifiers) override;
 
     /// Set offset to image rectangle used when pressed.
-    /// @property
     void SetPressedOffset(const IntVector2& offset);
     /// Set offset to image rectangle used when pressed.
     void SetPressedOffset(int x, int y);
     /// Set offset of child elements when pressed.
-    /// @property
     void SetPressedChildOffset(const IntVector2& offset);
     /// Set offset of child elements when pressed.
     void SetPressedChildOffset(int x, int y);
     /// Set repeat properties. Rate 0 (default) disables repeat.
     void SetRepeat(float delay, float rate);
     /// Set repeat delay.
-    /// @property
     void SetRepeatDelay(float delay);
     /// Set repeat rate.
-    /// @property
     void SetRepeatRate(float rate);
 
     /// Return pressed image offset.
-    /// @property
     const IntVector2& GetPressedOffset() const { return pressedOffset_; }
 
     /// Return offset of child elements when pressed.
-    /// @property
     const IntVector2& GetPressedChildOffset() const { return pressedChildOffset_; }
 
     /// Return repeat delay.
-    /// @property
     float GetRepeatDelay() const { return repeatDelay_; }
 
     /// Return repeat rate.
-    /// @property
     float GetRepeatRate() const { return repeatRate_; }
 
     /// Return whether is currently pressed.
-    /// @property
     bool IsPressed() const { return pressed_; }
 
 protected:

--- a/source/dviglo/ui/check_box.h
+++ b/source/dviglo/ui/check_box.h
@@ -32,20 +32,16 @@ public:
     void OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifiers) override;
 
     /// Set checked state.
-    /// @property
     void SetChecked(bool enable);
     /// Set checked image offset.
-    /// @property
     void SetCheckedOffset(const IntVector2& offset);
     /// Set checked image offset.
     void SetCheckedOffset(int x, int y);
 
     /// Return whether is checked.
-    /// @property
     bool IsChecked() const { return checked_; }
 
     /// Return checked image offset.
-    /// @property
     const IntVector2& GetCheckedOffset() const { return checkedOffset_; }
 
 protected:

--- a/source/dviglo/ui/cursor.h
+++ b/source/dviglo/ui/cursor.h
@@ -94,20 +94,16 @@ public:
     /// Define a shape.
     void DefineShape(CursorShape shape, Image* image, const IntRect& imageRect, const IntVector2& hotSpot);
     /// Set current shape.
-    /// @property
     void SetShape(const String& shape);
     /// Set current shape.
     void SetShape(CursorShape shape);
     /// Set whether to use system default shapes. Is only possible when the OS mouse cursor has been set visible from the Input subsystem.
-    /// @property
     void SetUseSystemShapes(bool enable);
 
     /// Get current shape.
-    /// @property
     const String& GetShape() const { return shape_; }
 
     /// Return whether is using system default shapes.
-    /// @property
     bool GetUseSystemShapes() const { return useSystemShapes_; }
 
     /// Set shapes attribute.

--- a/source/dviglo/ui/dropdown_list.h
+++ b/source/dviglo/ui/dropdown_list.h
@@ -56,7 +56,6 @@ public:
     /// Return number of items.
     i32 GetNumItems() const;
     /// Return item at index.
-    /// @property{get_items}
     UIElement* GetItem(i32 index) const;
     /// Return all items.
     Vector<UIElement*> GetItems() const;

--- a/source/dviglo/ui/dropdown_list.h
+++ b/source/dviglo/ui/dropdown_list.h
@@ -47,17 +47,13 @@ public:
     /// Remove all items.
     void RemoveAllItems();
     /// Set selection.
-    /// @property
     void SetSelection(i32 index);
     /// Set place holder text. This is the text shown when there is no selection (-1) in drop down list. Note that if the list has items, the default is to show the first item, so the "no selection" state has to be set explicitly.
-    /// @property
     void SetPlaceholderText(const String& text);
     /// Set whether popup should be automatically resized to match the dropdown button width.
-    /// @property
     void SetResizePopup(bool enable);
 
     /// Return number of items.
-    /// @property
     i32 GetNumItems() const;
     /// Return item at index.
     /// @property{get_items}
@@ -65,26 +61,20 @@ public:
     /// Return all items.
     Vector<UIElement*> GetItems() const;
     /// Return selection index, or NINDEX if none selected.
-    /// @property
     i32 GetSelection() const;
     /// Return selected item, or null if none selected.
-    /// @property
     UIElement* GetSelectedItem() const;
 
     /// Return listview element.
-    /// @property
     ListView* GetListView() const { return listView_; }
 
     /// Return selected item placeholder element.
-    /// @property
     UIElement* GetPlaceholder() const { return placeholder_; }
 
     /// Return place holder text.
-    /// @property
     const String& GetPlaceholderText() const;
 
     /// Return whether popup should be automatically resized.
-    /// @property
     bool GetResizePopup() const { return resizePopup_; }
 
     /// Set selection attribute.

--- a/source/dviglo/ui/file_selector.h
+++ b/source/dviglo/ui/file_selector.h
@@ -44,53 +44,41 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set fileselector UI style.
-    /// @property
     void SetDefaultStyle(XMLFile* style);
     /// Set title text.
-    /// @property
     void SetTitle(const String& text);
     /// Set button texts.
     void SetButtonTexts(const String& okText, const String& cancelText);
     /// Set current path.
-    /// @property
     void SetPath(const String& path);
     /// Set current filename.
-    /// @property
     void SetFileName(const String& fileName);
     /// Set filters.
     void SetFilters(const Vector<String>& filters, unsigned defaultIndex);
     /// Set directory selection mode. Default false.
-    /// @property
     void SetDirectoryMode(bool enable);
     /// Update elements to layout properly. Call this after manually adjusting the sub-elements.
     void UpdateElements();
 
     /// Return the UI style file.
-    /// @property
     XMLFile* GetDefaultStyle() const;
 
     /// Return fileselector window.
-    /// @property
     Window* GetWindow() const { return window_; }
 
     /// Return window title text element.
-    /// @property
     Text* GetTitleText() const { return titleText_; }
 
     /// Return file list.
-    /// @property
     ListView* GetFileList() const { return fileList_; }
 
     /// Return path editor.
-    /// @property
     LineEdit* GetPathEdit() const { return pathEdit_; }
 
     /// Return filename editor.
-    /// @property
     LineEdit* GetFileNameEdit() const { return fileNameEdit_; }
 
     /// Return filter dropdown.
-    /// @property
     DropDownList* GetFilterList() const { return filterList_; }
 
     /// Return OK button.
@@ -98,32 +86,25 @@ public:
     Button* GetOKButton() const { return okButton_; }
 
     /// Return cancel button.
-    /// @property
     Button* GetCancelButton() const { return cancelButton_; }
 
     /// Return close button.
     Button* GetCloseButton() const { return closeButton_; }
 
     /// Return window title.
-    /// @property
     const String& GetTitle() const;
 
     /// Return current path.
-    /// @property
     const String& GetPath() const { return path_; }
 
     /// Return current filename.
-    /// @property
     const String& GetFileName() const;
     /// Return current filter.
-    /// @property
     const String& GetFilter() const;
     /// Return current filter index.
-    /// @property
     unsigned GetFilterIndex() const;
 
     /// Return directory mode flag.
-    /// @property
     bool GetDirectoryMode() const { return directoryMode_; }
 
 private:

--- a/source/dviglo/ui/file_selector.h
+++ b/source/dviglo/ui/file_selector.h
@@ -82,7 +82,6 @@ public:
     DropDownList* GetFilterList() const { return filterList_; }
 
     /// Return OK button.
-    /// @property{get_okButton}
     Button* GetOKButton() const { return okButton_; }
 
     /// Return cancel button.

--- a/source/dviglo/ui/font.h
+++ b/source/dviglo/ui/font.h
@@ -45,28 +45,23 @@ public:
     /// Save resource as a new bitmap font type in XML format. Return true if successful.
     bool SaveXML(Serializer& dest, int pointSize, bool usedGlyphs = false, const String& indentation = "\t");
     /// Set absolute (in pixels) position adjustment for glyphs.
-    /// @property
     void SetAbsoluteGlyphOffset(const IntVector2& offset);
     /// Set point size scaled position adjustment for glyphs.
-    /// @property
     void SetScaledGlyphOffset(const Vector2& offset);
 
     /// Return font face. Pack and render to a texture if not rendered yet. Return null on error.
     FontFace* GetFace(float pointSize);
 
     /// Return font type.
-    /// @property
     FontType GetFontType() const { return fontType_; }
 
     /// Is signed distance field font.
     bool IsSDFFont() const { return sdfFont_; }
 
     /// Return absolute position adjustment for glyphs.
-    /// @property
     const IntVector2& GetAbsoluteGlyphOffset() const { return absoluteOffset_; }
 
     /// Return point size scaled position adjustment for glyphs.
-    /// @property
     const Vector2& GetScaledGlyphOffset() const { return scaledOffset_; }
 
     /// Return the total effective offset for a point size.

--- a/source/dviglo/ui/line_edit.h
+++ b/source/dviglo/ui/line_edit.h
@@ -53,68 +53,50 @@ public:
     void OnTextInput(const String& text) override;
 
     /// Set text.
-    /// @property
     void SetText(const String& text);
     /// Set cursor position.
-    /// @property
     void SetCursorPosition(i32 position);
     /// Set cursor blink rate. 0 disables blinking.
-    /// @property
     void SetCursorBlinkRate(float rate);
     /// Set maximum text length. 0 for unlimited.
-    /// @property
     void SetMaxLength(i32 length);
     /// Set echo character for password entry and such. 0 (default) shows the actual text.
-    /// @property
     void SetEchoCharacter(c32 c);
     /// Set whether can move cursor with arrows or mouse, default true.
-    /// @property
     void SetCursorMovable(bool enable);
     /// Set whether selections are allowed, default true.
-    /// @property
     void SetTextSelectable(bool enable);
     /// Set whether copy-paste operations are allowed, default true.
-    /// @property
     void SetTextCopyable(bool enable);
 
     /// Return text.
-    /// @property
     const String& GetText() const { return line_; }
 
     /// Return cursor position.
-    /// @property
     i32 GetCursorPosition() const { return cursorPosition_; }
 
     /// Return cursor blink rate.
-    /// @property
     float GetCursorBlinkRate() const { return cursorBlinkRate_; }
 
     /// Return maximum text length.
-    /// @property
     i32 GetMaxLength() const { return maxLength_; }
 
     /// Return echo character.
-    /// @property
     c32 GetEchoCharacter() const { return echoCharacter_; }
 
     /// Return whether can move cursor with arrows or mouse.
-    /// @property
     bool IsCursorMovable() const { return cursorMovable_; }
 
     /// Return whether selections are allowed.
-    /// @property
     bool IsTextSelectable() const { return textSelectable_; }
 
     /// Return whether copy-paste operations are allowed.
-    /// @property
     bool IsTextCopyable() const { return textCopyable_; }
 
     /// Return text element.
-    /// @property
     Text* GetTextElement() const { return text_; }
 
     /// Return cursor element.
-    /// @property
     BorderImage* GetCursor() const { return cursor_; }
 
 protected:

--- a/source/dviglo/ui/list_view.h
+++ b/source/dviglo/ui/list_view.h
@@ -66,7 +66,6 @@ public:
     /// Remove all items.
     void RemoveAllItems();
     /// Set selection.
-    /// @property
     void SetSelection(i32 index);
     /// Set multiple selected items. If multiselect disabled, sets only the first.
     void SetSelections(const Vector<i32>& indices);
@@ -81,23 +80,17 @@ public:
     /// Clear selection.
     void ClearSelection();
     /// Set selected items' highlight mode.
-    /// @property
     void SetHighlightMode(HighlightMode mode);
     /// Enable multiselect.
-    /// @property
     void SetMultiselect(bool enable);
     /// \brief Enable hierarchy mode. Allows items to have parent-child relationship at different indent level and the ability to expand/collapse child items.
     /// All items in the list will be lost during mode change.
-    /// @property
     void SetHierarchyMode(bool enable);
     /// Set base indent, i.e. the indent level of the ultimate parent item.
-    /// @property
     void SetBaseIndent(int baseIndent);
     /// Enable clearing of selection on defocus.
-    /// @property
     void SetClearSelectionOnDefocus(bool enable);
     /// Enable reacting to click end instead of click start for item selection. Default false.
-    /// @property
     void SetSelectOnClickEnd(bool enable);
 
     /// Expand item at index. Only has effect in hierarchy mode.
@@ -106,7 +99,6 @@ public:
     void ToggleExpand(i32 index, bool recursive = false);
 
     /// Return number of items.
-    /// @property
     i32 GetNumItems() const;
     /// Return item at index.
     /// @property{get_items}
@@ -116,20 +108,16 @@ public:
     /// Return index of item, or NINDEX If not found.
     i32 FindItem(UIElement* item) const;
     /// Return first selected index, or NINDEX if none selected.
-    /// @property
     i32 GetSelection() const;
 
     /// Return all selected indices.
-    /// @property
     const Vector<i32>& GetSelections() const { return selections_; }
 
     /// Copy selected items to system clipboard. Currently only applicable to Text items.
     void CopySelectedItemsToClipboard() const;
     /// Return first selected item, or null if none selected.
-    /// @property
     UIElement* GetSelectedItem() const;
     /// Return all selected items.
-    /// @property
     Vector<UIElement*> GetSelectedItems() const;
     /// Return whether an item at index is selected.
     bool IsSelected(i32 index) const;
@@ -137,27 +125,21 @@ public:
     bool IsExpanded(i32 index) const;
 
     /// Return highlight mode.
-    /// @property
     HighlightMode GetHighlightMode() const { return highlightMode_; }
 
     /// Return whether multiselect enabled.
-    /// @property
     bool GetMultiselect() const { return multiselect_; }
 
     /// Return whether selection is cleared on defocus.
-    /// @property
     bool GetClearSelectionOnDefocus() const { return clearSelectionOnDefocus_; }
 
     /// Return whether reacts to click end instead of click start for item selection.
-    /// @property
     bool GetSelectOnClickEnd() const { return selectOnClickEnd_; }
 
     /// Return whether hierarchy mode enabled.
-    /// @property
     bool GetHierarchyMode() const { return hierarchyMode_; }
 
     /// Return base indent.
-    /// @property
     int GetBaseIndent() const { return baseIndent_; }
 
     /// Ensure full visibility of the item.

--- a/source/dviglo/ui/list_view.h
+++ b/source/dviglo/ui/list_view.h
@@ -101,7 +101,6 @@ public:
     /// Return number of items.
     i32 GetNumItems() const;
     /// Return item at index.
-    /// @property{get_items}
     UIElement* GetItem(i32 index) const;
     /// Return all items.
     Vector<UIElement*> GetItems() const;

--- a/source/dviglo/ui/menu.h
+++ b/source/dviglo/ui/menu.h
@@ -42,37 +42,29 @@ public:
     virtual void OnHidePopup() { }
 
     /// Set popup element to show on selection.
-    /// @property
     void SetPopup(UIElement* popup);
     /// Set popup element offset.
-    /// @property
     void SetPopupOffset(const IntVector2& offset);
     /// Set popup element offset.
     void SetPopupOffset(int x, int y);
     /// Force the popup to show or hide.
-    /// @property
     void ShowPopup(bool enable);
     /// Set accelerator key (set zero key code to disable).
     void SetAccelerator(int key, int qualifiers);
 
     /// Return popup element.
-    /// @property
     UIElement* GetPopup() const { return popup_; }
 
     /// Return popup element offset.
-    /// @property
     const IntVector2& GetPopupOffset() const { return popupOffset_; }
 
     /// Return whether popup is open.
-    /// @property
     bool GetShowPopup() const { return showPopup_; }
 
     /// Return accelerator key code, 0 if disabled.
-    /// @property
     int GetAcceleratorKey() const { return acceleratorKey_; }
 
     /// Return accelerator qualifiers.
-    /// @property
     int GetAcceleratorQualifiers() const { return acceleratorQualifiers_; }
 
 protected:

--- a/source/dviglo/ui/message_box.h
+++ b/source/dviglo/ui/message_box.h
@@ -30,21 +30,16 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set title text. No-ops if there is no title text element.
-    /// @property
     void SetTitle(const String& text);
     /// Set message text. No-ops if there is no message text element.
-    /// @property
     void SetMessage(const String& text);
 
     /// Return title text. Return empty string if there is no title text element.
-    /// @property
     const String& GetTitle() const;
     /// Return message text. Return empty string if there is no message text element.
-    /// @property
     const String& GetMessage() const;
 
     /// Return dialog window.
-    /// @property
     UIElement* GetWindow() const { return window_; }
 
 private:

--- a/source/dviglo/ui/progress_bar.h
+++ b/source/dviglo/ui/progress_bar.h
@@ -31,34 +31,27 @@ public:
     void OnResize(const IntVector2& newSize, const IntVector2& delta) override;
 
     /// Set orientation type.
-    /// @property
     void SetOrientation(Orientation orientation);
 
     /// Set ProgressBar range maximum value (minimum value is always 0).
-    /// @property
     void SetRange(float range);
 
     /// Set ProgressBar current value.
-    /// @property
     void SetValue(float value);
 
     /// Change value by a delta.
     void ChangeValue(float delta);
 
     /// Return orientation type.
-    /// @property
     Orientation GetOrientation() const { return orientation_; }
 
     /// Return ProgressBar range.
-    /// @property
     float GetRange() const { return range_; }
 
     /// Return ProgressBar current value.
-    /// @property
     float GetValue() const { return value_; }
 
     /// Return knob element.
-    /// @property
     BorderImage *GetKnob() const { return knob_; }
 
     /// Sets the loading percent style.
@@ -68,11 +61,9 @@ public:
     const String& GetLoadingPercentStyle() const { return loadingPercentStyle_; }
 
     /// Sets the flag to display the percent text.
-    /// @property
     void SetShowPercentText(bool enable);
 
     /// Returns the flag to display the percent text.
-    /// @property
     bool GetShowPercentText() const { return showPercentText_; }
 
 protected:

--- a/source/dviglo/ui/scroll_bar.h
+++ b/source/dviglo/ui/scroll_bar.h
@@ -34,21 +34,16 @@ public:
     void OnSetEditable() override;
 
     /// Set orientation type.
-    /// @property
     void SetOrientation(Orientation orientation);
     /// Set slider range maximum value (minimum value is always 0).
-    /// @property
     void SetRange(float range);
     /// Set slider current value.
-    /// @property
     void SetValue(float value);
     /// Change slider current value by a delta.
     void ChangeValue(float delta);
     /// Set button scroll step.
-    /// @property
     void SetScrollStep(float step);
     /// Set button step factor, can be used to adjust the step for constant pixel size.
-    /// @property
     void SetStepFactor(float factor);
     /// Scroll back one step.
     void StepBack();
@@ -56,37 +51,28 @@ public:
     void StepForward();
 
     /// Return scrollbar orientation.
-    /// @property
     Orientation GetOrientation() const;
     /// Return slider range.
-    /// @property
     float GetRange() const;
     /// Return slider current value.
-    /// @property
     float GetValue() const;
 
     /// Return button scroll step.
-    /// @property
     float GetScrollStep() const { return scrollStep_; }
 
     /// Return button step factor.
-    /// @property
     float GetStepFactor() const { return stepFactor_; }
 
     /// Return scroll step multiplied by factor.
-    /// @property
     float GetEffectiveScrollStep() const;
 
     /// Return back button element.
-    /// @property
     Button* GetBackButton() const { return backButton_; }
 
     /// Return forward button element.
-    /// @property
     Button* GetForwardButton() const { return forwardButton_; }
 
     /// Return slider element.
-    /// @property
     Slider* GetSlider() const { return slider_; }
 
 protected:

--- a/source/dviglo/ui/scroll_view.h
+++ b/source/dviglo/ui/scroll_view.h
@@ -41,101 +41,76 @@ public:
     bool IsWheelHandler() const override { return true; }
 
     /// Set content element.
-    /// @property
     void SetContentElement(UIElement* element);
     /// Set view offset from the top-left corner.
-    /// @property
     void SetViewPosition(const IntVector2& position);
     /// Set view offset from the top-left corner.
     void SetViewPosition(int x, int y);
     /// Set scrollbars' visibility manually. Disables scrollbar autoshow/hide.
     void SetScrollBarsVisible(bool horizontal, bool vertical);
     /// Set horizontal scrollbar visibility manually. Disables scrollbar autoshow/hide.
-    /// @property
     void SetHorizontalScrollBarVisible(bool visible);
     /// Set vertical scrollbar visibility manually. Disables scrollbar autoshow/hide.
-    /// @property
     void SetVerticalScrollBarVisible(bool visible);
     /// Set whether to automatically show/hide scrollbars. Default true.
-    /// @property
     void SetScrollBarsAutoVisible(bool enable);
     /// Set arrow key scroll step. Also sets it on the scrollbars.
-    /// @property
     void SetScrollStep(float step);
     /// Set arrow key page step.
-    /// @property
     void SetPageStep(float step);
 
     /// Set scroll deceleration.
-    /// @property
     void SetScrollDeceleration(float deceleration) { scrollDeceleration_ = deceleration; }
 
     /// Set scroll snap epsilon.
-    /// @property
     void SetScrollSnapEpsilon(float snap) { scrollSnapEpsilon_ = snap; }
 
     /// Set whether child elements should be disabled while touch scrolling.
-    /// @property
     void SetAutoDisableChildren(bool disable) { autoDisableChildren_ = disable; };
 
     /// Set how much touch movement is needed to trigger child element disabling.
-    /// @property
     void SetAutoDisableThreshold(float amount) { autoDisableThreshold_ = amount; };
 
     /// Return view offset from the top-left corner.
-    /// @property
     const IntVector2& GetViewPosition() const { return viewPosition_; }
 
     /// Return content element.
-    /// @property
     UIElement* GetContentElement() const { return contentElement_; }
 
     /// Return horizontal scroll bar.
-    /// @property
     ScrollBar* GetHorizontalScrollBar() const { return horizontalScrollBar_; }
 
     /// Return vertical scroll bar.
-    /// @property
     ScrollBar* GetVerticalScrollBar() const { return verticalScrollBar_; }
 
     /// Return scroll panel.
-    /// @property
     BorderImage* GetScrollPanel() const { return scrollPanel_; }
 
     /// Return whether scrollbars are automatically shown/hidden.
-    /// @property
     bool GetScrollBarsAutoVisible() const { return scrollBarsAutoVisible_; }
 
     /// Return whether the horizontal scrollbar is visible.
-    /// @property
     bool GetHorizontalScrollBarVisible() const;
 
     /// Return whether the vertical scrollbar is visible.
-    /// @property
     bool GetVerticalScrollBarVisible() const;
 
     /// Return arrow key scroll step.
-    /// @property
     float GetScrollStep() const;
 
     /// Return arrow key page step.
-    /// @property
     float GetPageStep() const { return pageStep_; }
 
     /// Return scroll deceleration.
-    /// @property
     float GetScrollDeceleration() const { return scrollDeceleration_; }
 
     /// Return scroll snap epsilon.
-    /// @property
     float GetScrollSnapEpsilon() const { return scrollSnapEpsilon_; }
 
     /// Return whether child element will be disabled while touch scrolling.
-    /// @property
     bool GetAutoDisableChildren() const { return autoDisableChildren_; }
 
     /// Return how much touch movement is needed to trigger child element disabling.
-    /// @property
     float GetAutoDisableThreshold() const { return autoDisableThreshold_; }
 
     /// Set view position attribute.

--- a/source/dviglo/ui/slider.h
+++ b/source/dviglo/ui/slider.h
@@ -48,38 +48,29 @@ public:
     void OnResize(const IntVector2& newSize, const IntVector2& delta) override;
 
     /// Set orientation type.
-    /// @property
     void SetOrientation(Orientation orientation);
     /// Set slider range maximum value (minimum value is always 0).
-    /// @property
     void SetRange(float range);
     /// Set slider current value.
-    /// @property
     void SetValue(float value);
     /// Change value by a delta.
     void ChangeValue(float delta);
     /// Set paging minimum repeat rate (number of events per second).
-    /// @property
     void SetRepeatRate(float rate);
 
     /// Return orientation type.
-    /// @property
     Orientation GetOrientation() const { return orientation_; }
 
     /// Return slider range.
-    /// @property
     float GetRange() const { return range_; }
 
     /// Return slider current value.
-    /// @property
     float GetValue() const { return value_; }
 
     /// Return knob element.
-    /// @property
     BorderImage* GetKnob() const { return knob_; }
 
     /// Return paging minimum repeat rate (number of events per second).
-    /// @property
     float GetRepeatRate() const { return repeatRate_; }
 
 protected:

--- a/source/dviglo/ui/sprite.h
+++ b/source/dviglo/ui/sprite.h
@@ -38,63 +38,49 @@ public:
     IntVector2 ElementToScreen(const IntVector2& position) override;
 
     /// Set floating point position.
-    /// @property
     void SetPosition(const Vector2& position);
     /// Set floating point position.
     void SetPosition(float x, float y);
     /// Set hotspot for positioning and rotation.
-    /// @property
     void SetHotSpot(const IntVector2& hotSpot);
     /// Set hotspot for positioning and rotation.
     void SetHotSpot(int x, int y);
     /// Set scale. Scale also affects child sprites.
-    /// @property
     void SetScale(const Vector2& scale);
     /// Set scale. Scale also affects child sprites.
     void SetScale(float x, float y);
     /// Set uniform scale. Scale also affects child sprites.
     void SetScale(float scale);
     /// Set rotation angle.
-    /// @property
     void SetRotation(float angle);
     /// Set texture.
-    /// @property
     void SetTexture(Texture* texture);
     /// Set part of texture to use as the image.
-    /// @property
     void SetImageRect(const IntRect& rect);
     /// Use whole texture as the image.
     void SetFullImageRect();
     /// Set blend mode.
-    /// @property
     void SetBlendMode(BlendMode mode);
 
     /// Return floating point position.
-    /// @property
     const Vector2& GetPosition() const { return floatPosition_; }
 
     /// Return hotspot.
-    /// @property
     const IntVector2& GetHotSpot() const { return hotSpot_; }
 
     /// Return scale.
-    /// @property
     const Vector2& GetScale() const { return scale_; }
 
     /// Return rotation angle.
-    /// @property
     float GetRotation() const { return rotation_; }
 
     /// Return texture.
-    /// @property
     Texture* GetTexture() const { return texture_; }
 
     /// Return image rectangle.
-    /// @property
     const IntRect& GetImageRect() const { return imageRect_; }
 
     /// Return blend mode.
-    /// @property
     BlendMode GetBlendMode() const { return blendMode_; }
 
     /// Set texture attribute.

--- a/source/dviglo/ui/text.h
+++ b/source/dviglo/ui/text.h
@@ -165,13 +165,10 @@ public:
     i32 GetNumChars() const { return unicodeText_.Size(); }
 
     /// Return width of row by index.
-    /// @property{get_rowWidths}
     float GetRowWidth(i32 index) const;
     /// Return position of character by index relative to the text element origin.
-    /// @property{get_charPositions}
     Vector2 GetCharPosition(i32 index);
     /// Return size of character by index.
-    /// @property{get_charSizes}
     Vector2 GetCharSize(i32 index);
 
     /// Set text effect Z bias. Zero by default, adjusted only in 3D mode.

--- a/source/dviglo/ui/text.h
+++ b/source/dviglo/ui/text.h
@@ -87,109 +87,81 @@ public:
     /// Set font and font size. Return true if successful.
     bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
     /// Set font size only while retaining the existing font. Return true if successful.
-    /// @property
     bool SetFontSize(float size);
     /// Set text. Text is assumed to be either ASCII or UTF8-encoded.
-    /// @property
     void SetText(const String& text);
     /// Set row alignment.
-    /// @property
     void SetTextAlignment(HorizontalAlignment align);
     /// Set row spacing, 1.0 for original font spacing.
-    /// @property
     void SetRowSpacing(float spacing);
     /// Set wordwrap. In wordwrap mode the text element will respect its current width. Otherwise it resizes itself freely.
-    /// @property
     void SetWordwrap(bool enable);
     /// The text will be automatically translated. The text value used as string identifier.
-    /// @property
     void SetAutoLocalizable(bool enable);
     /// Set selection. When length is not provided, select until the text ends.
     void SetSelection(i32 start, i32 length = M_MAX_INT);
     /// Clear selection.
     void ClearSelection();
     /// Set text effect.
-    /// @property
     void SetTextEffect(TextEffect textEffect);
     /// Set shadow offset.
-    /// @property
     void SetEffectShadowOffset(const IntVector2& offset);
     /// Set stroke thickness.
-    /// @property
     void SetEffectStrokeThickness(int thickness);
     /// Set stroke rounding. Corners of the font will be rounded off in the stroke so the stroke won't have corners.
-    /// @property
     void SetEffectRoundStroke(bool roundStroke);
     /// Set effect color.
-    /// @property
     void SetEffectColor(const Color& effectColor);
 
     /// Return font.
-    /// @property
     Font* GetFont() const { return font_; }
 
     /// Return font size.
-    /// @property
     float GetFontSize() const { return fontSize_; }
 
     /// Return text.
-    /// @property
     const String& GetText() const { return text_; }
 
     /// Return row alignment.
-    /// @property
     HorizontalAlignment GetTextAlignment() const { return textAlignment_; }
 
     /// Return row spacing.
-    /// @property
     float GetRowSpacing() const { return rowSpacing_; }
 
     /// Return wordwrap mode.
-    /// @property
     bool GetWordwrap() const { return wordWrap_; }
 
     /// Return auto localizable mode.
-    /// @property
     bool GetAutoLocalizable() const { return autoLocalizable_; }
 
     /// Return selection start.
-    /// @property
     i32 GetSelectionStart() const { return selectionStart_; }
 
     /// Return selection length.
-    /// @property
     i32 GetSelectionLength() const { return selectionLength_; }
 
     /// Return text effect.
-    /// @property
     TextEffect GetTextEffect() const { return textEffect_; }
 
     /// Return effect shadow offset.
-    /// @property
     const IntVector2& GetEffectShadowOffset() const { return shadowOffset_; }
 
     /// Return effect stroke thickness.
-    /// @property
     int GetEffectStrokeThickness() const { return strokeThickness_; }
 
     /// Return effect round stroke.
-    /// @property
     bool GetEffectRoundStroke() const { return roundStroke_; }
 
     /// Return effect color.
-    /// @property
     const Color& GetEffectColor() const { return effectColor_; }
 
     /// Return row height.
-    /// @property
     float GetRowHeight() const { return rowHeight_; }
 
     /// Return number of rows.
-    /// @property
     i32 GetNumRows() const { return rowWidths_.Size(); }
 
     /// Return number of characters.
-    /// @property
     i32 GetNumChars() const { return unicodeText_.Size(); }
 
     /// Return width of row by index.

--- a/source/dviglo/ui/text_3d.h
+++ b/source/dviglo/ui/text_3d.h
@@ -76,7 +76,6 @@ public:
     /// Set color on all corners.
     void SetColor(const Color& color);
     /// Set color on one corner.
-    /// @property{set_colors}
     void SetColor(Corner corner, const Color& color);
     /// Set opacity.
     void SetOpacity(float opacity);
@@ -126,16 +125,12 @@ public:
     /// Return number of characters.
     i32 GetNumChars() const;
     /// Return width of row by index.
-    /// @property{get_rowWidths}
     int GetRowWidth(i32 index) const;
     /// Return position of character by index relative to the text element origin.
-    /// @property{get_charPositions}
     Vector2 GetCharPosition(i32 index);
     /// Return size of character by index.
-    /// @property{get_charSizes}
     Vector2 GetCharSize(i32 index);
     /// Return corner color.
-    /// @property{get_colors}
     const Color& GetColor(Corner corner) const;
     /// Return opacity.
     float GetOpacity() const;

--- a/source/dviglo/ui/text_3d.h
+++ b/source/dviglo/ui/text_3d.h
@@ -42,127 +42,88 @@ public:
     /// Set font and font size. Return true if successful.
     bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
     /// Set font size only while retaining the existing font. Return true if successful.
-    /// @property
     bool SetFontSize(float size);
     /// Set material.
-    /// @property
     void SetMaterial(Material* material);
     /// Set text. Text is assumed to be either ASCII or UTF8-encoded.
-    /// @property
     void SetText(const String& text);
     /// Set horizontal and vertical alignment.
     void SetAlignment(HorizontalAlignment hAlign, VerticalAlignment vAlign);
     /// Set horizontal alignment.
-    /// @property
     void SetHorizontalAlignment(HorizontalAlignment align);
     /// Set vertical alignment.
-    /// @property
     void SetVerticalAlignment(VerticalAlignment align);
     /// Set row alignment.
-    /// @property
     void SetTextAlignment(HorizontalAlignment align);
     /// Set row spacing, 1.0 for original font spacing.
-    /// @property
     void SetRowSpacing(float spacing);
     /// Set wordwrap. In wordwrap mode the text element will respect its current width. Otherwise it resizes itself freely.
-    /// @property
     void SetWordwrap(bool enable);
     /// Set text effect.
-    /// @property
     void SetTextEffect(TextEffect textEffect);
     /// Set shadow offset.
-    /// @property
     void SetEffectShadowOffset(const IntVector2& offset);
     /// Set stroke thickness.
-    /// @property
     void SetEffectStrokeThickness(int thickness);
     /// Set stroke rounding. Corners of the font will be rounded off in the stroke so the stroke won't have corners.
-    /// @property
     void SetEffectRoundStroke(bool roundStroke);
     /// Set effect color.
-    /// @property
     void SetEffectColor(const Color& effectColor);
     /// Set effect Z bias.
-    /// @property
     void SetEffectDepthBias(float bias);
     /// Set text width. Only has effect in word wrap mode.
-    /// @property
     void SetWidth(int width);
     /// Set color on all corners.
-    /// @property
     void SetColor(const Color& color);
     /// Set color on one corner.
     /// @property{set_colors}
     void SetColor(Corner corner, const Color& color);
     /// Set opacity.
-    /// @property
     void SetOpacity(float opacity);
     /// Set whether text has fixed size on screen (pixel-perfect) regardless of distance to camera. Works best when combined with face camera rotation. Default false.
-    /// @property
     void SetFixedScreenSize(bool enable);
     /// Set how the text should rotate in relation to the camera. Default is to not rotate (FC_NONE).
-    /// @property
     void SetFaceCameraMode(FaceCameraMode mode);
 
     /// Return font.
-    /// @property
     Font* GetFont() const;
     /// Return font size.
-    /// @property
     float GetFontSize() const;
     /// Return material.
-    /// @property
     Material* GetMaterial() const;
     /// Return text.
-    /// @property
     const String& GetText() const;
     /// Return row alignment.
-    /// @property
     HorizontalAlignment GetTextAlignment() const;
     /// Return horizontal alignment.
-    /// @property
     HorizontalAlignment GetHorizontalAlignment() const;
     /// Return vertical alignment.
-    /// @property
     VerticalAlignment GetVerticalAlignment() const;
     /// Return row spacing.
-    /// @property
     float GetRowSpacing() const;
     /// Return wordwrap mode.
-    /// @property
     bool GetWordwrap() const;
     /// Return text effect.
-    /// @property
     TextEffect GetTextEffect() const;
     /// Return effect shadow offset.
-    /// @property
     const IntVector2& GetEffectShadowOffset() const;
     /// Return effect stroke thickness.
-    /// @property
     int GetEffectStrokeThickness() const;
     /// Return effect round stroke.
-    /// @property
     bool GetEffectRoundStroke() const;
     /// Return effect color.
-    /// @property
     const Color& GetEffectColor() const;
     /// Return effect depth bias.
-    /// @property
     float GetEffectDepthBias() const;
     /// Return text width.
-    /// @property
     int GetWidth() const;
     /// Return text height.
-    /// @property
     int GetHeight() const;
     /// Return row height.
-    /// @property
     int GetRowHeight() const;
     /// Return number of rows.
-    /// @property
     i32 GetNumRows() const;
     /// Return number of characters.
-    /// @property
     i32 GetNumChars() const;
     /// Return width of row by index.
     /// @property{get_rowWidths}
@@ -177,13 +138,10 @@ public:
     /// @property{get_colors}
     const Color& GetColor(Corner corner) const;
     /// Return opacity.
-    /// @property
     float GetOpacity() const;
     /// Return whether text has fixed screen size.
-    /// @property
     bool IsFixedScreenSize() const { return fixedScreenSize_; }
     /// Return how the text rotates in relation to the camera.
-    /// @property
     FaceCameraMode GetFaceCameraMode() const { return faceCameraMode_; }
 
     /// Set font attribute.

--- a/source/dviglo/ui/tooltip.h
+++ b/source/dviglo/ui/tooltip.h
@@ -34,11 +34,9 @@ public:
     void AddAltTarget(UIElement* target);
 
     /// Set the delay in seconds until the tooltip shows once hovering. Set zero to use the default from the UI subsystem.
-    /// @property
     void SetDelay(float delay);
 
     /// Return the delay in seconds until the tooltip shows once hovering.
-    /// @property
     float GetDelay() const { return delay_; }
 
 private:

--- a/source/dviglo/ui/ui.h
+++ b/source/dviglo/ui/ui.h
@@ -117,7 +117,6 @@ public:
     UIElement* GetRoot() const { return rootElement_; }
 
     /// Return root modal element.
-    /// @property{get_modalRoot}
     UIElement* GetRootModalElement() const { return rootModalElement_; }
 
     /// Return cursor.

--- a/source/dviglo/ui/ui.h
+++ b/source/dviglo/ui/ui.h
@@ -50,7 +50,6 @@ public:
     ~UI() override;
 
     /// Set cursor UI element.
-    /// @property
     void SetCursor(Cursor* cursor);
     /// Set focused UI element.
     void SetFocusElement(UIElement* element, bool byKey = false);
@@ -74,65 +73,47 @@ public:
     /// Save a UI layout to an XML file. Return true if successful.
     bool SaveLayout(Serializer& dest, UIElement* element);
     /// Set clipboard text.
-    /// @property
     void SetClipboardText(const String& text);
     /// Set UI element double click interval in seconds.
-    /// @property
     void SetDoubleClickInterval(float interval);
     /// Set max screen distance in pixels between double click clicks.
-    /// @property
     void SetMaxDoubleClickDistance(float distPixels);
     /// Set UI drag event start interval in seconds.
-    /// @property
     void SetDragBeginInterval(float interval);
     /// Set UI drag event start distance threshold in pixels.
-    /// @property
     void SetDragBeginDistance(int pixels);
     /// Set tooltip default display delay in seconds.
-    /// @property
     void SetDefaultToolTipDelay(float delay);
     /// Set maximum font face texture size. Must be a power of two. Default is 2048.
-    /// @property
     void SetMaxFontTextureSize(int size);
     /// Set whether mouse wheel can control also a non-focused element.
-    /// @property
     void SetNonFocusedMouseWheel(bool nonFocusedMouseWheel);
     /// Set whether to use system clipboard. Default false.
-    /// @property
     void SetUseSystemClipboard(bool enable);
     /// Set whether to show the on-screen keyboard (if supported) when a %LineEdit is focused. Default true on mobile devices.
-    /// @property
     void SetUseScreenKeyboard(bool enable);
     /// Set whether to use mutable (eraseable) glyphs to ensure a font face never expands to more than one texture. Default false.
-    /// @property
     void SetUseMutableGlyphs(bool enable);
     /// Set whether to force font autohinting instead of using FreeType's TTF bytecode interpreter.
-    /// @property
     void SetForceAutoHint(bool enable);
     /// Set the hinting level used by FreeType fonts.
-    /// @property
     void SetFontHintLevel(FontHintLevel level);
     /// Set the font subpixel threshold. Below this size, if the hint level is LIGHT or NONE, fonts will use subpixel positioning plus oversampling for higher-quality rendering. Has no effect at hint level NORMAL.
-    /// @property
     void SetFontSubpixelThreshold(float threshold);
     /// Set the oversampling (horizonal stretching) used to improve subpixel font rendering. Only affects fonts smaller than the subpixel limit.
-    /// @property
     void SetFontOversampling(int oversampling);
     /// Set %UI scale. 1.0 is default (pixel perfect). Resize the root element to match.
-    /// @property
     void SetScale(float scale);
     /// Scale %UI to the specified width in pixels.
     void SetWidth(float width);
     /// Scale %UI to the specified height in pixels.
     void SetHeight(float height);
     /// Set custom size of the root element. This disables automatic resizing of the root element according to window size. Set custom size 0,0 to return to automatic resizing.
-    /// @property
     void SetCustomSize(const IntVector2& size);
     /// Set custom size of the root element.
     void SetCustomSize(int width, int height);
 
     /// Return root UI element.
-    /// @property
     UIElement* GetRoot() const { return rootElement_; }
 
     /// Return root modal element.
@@ -140,11 +121,9 @@ public:
     UIElement* GetRootModalElement() const { return rootModalElement_; }
 
     /// Return cursor.
-    /// @property
     Cursor* GetCursor() const { return cursor_; }
 
     /// Return cursor position.
-    /// @property
     IntVector2 GetCursorPosition() const;
     /// Return UI element at global screen coordinates. By default returns only input-enabled elements.
     UIElement* GetElementAt(const IntVector2& position, bool enabledOnly = true);
@@ -158,11 +137,9 @@ public:
     IntVector2 ConvertUIToSystem(const IntVector2& uiPos) const;
 
     /// Return focused element.
-    /// @property
     UIElement* GetFocusElement() const { return focusElement_; }
 
     /// Return topmost enabled root-level non-modal element.
-    /// @property
     UIElement* GetFrontElement() const;
     /// Return currently dragged elements.
     /// @nobindtemp
@@ -174,63 +151,48 @@ public:
     /// Return the drag element at index.
     UIElement* GetDragElement(unsigned index);
     /// Return clipboard text.
-    /// @property
     const String& GetClipboardText() const;
 
     /// Return UI element double click interval in seconds.
-    /// @property
     float GetDoubleClickInterval() const { return doubleClickInterval_; }
 
     /// Return max screen distance in pixels for double clicks to register.
-    /// @property
     float GetMaxDoubleClickDistance() const { return maxDoubleClickDist_;}
 
     /// Return UI drag start event interval in seconds.
-    /// @property
     float GetDragBeginInterval() const { return dragBeginInterval_; }
 
     /// Return UI drag start event distance threshold in pixels.
-    /// @property
     int GetDragBeginDistance() const { return dragBeginDistance_; }
 
     /// Return tooltip default display delay in seconds.
-    /// @property
     float GetDefaultToolTipDelay() const { return defaultToolTipDelay_; }
 
     /// Return font texture maximum size.
-    /// @property
     int GetMaxFontTextureSize() const { return maxFontTextureSize_; }
 
     /// Return whether mouse wheel can control also a non-focused element.
-    /// @property
     bool IsNonFocusedMouseWheel() const { return nonFocusedMouseWheel_; }
 
     /// Return whether is using the system clipboard.
-    /// @property
     bool GetUseSystemClipboard() const { return useSystemClipboard_; }
 
     /// Return whether focusing a %LineEdit will show the on-screen keyboard.
-    /// @property
     bool GetUseScreenKeyboard() const { return useScreenKeyboard_; }
 
     /// Return whether is using mutable (eraseable) glyphs for fonts.
-    /// @property
     bool GetUseMutableGlyphs() const { return useMutableGlyphs_; }
 
     /// Return whether is using forced autohinting.
-    /// @property
     bool GetForceAutoHint() const { return forceAutoHint_; }
 
     /// Return the current FreeType font hinting level.
-    /// @property
     FontHintLevel GetFontHintLevel() const { return fontHintLevel_; }
 
     /// Get the font subpixel threshold. Below this size, if the hint level is LIGHT or NONE, fonts will use subpixel positioning plus oversampling for higher-quality rendering. Has no effect at hint level NORMAL.
-    /// @property
     float GetFontSubpixelThreshold() const { return fontSubpixelThreshold_; }
 
     /// Get the oversampling (horizonal stretching) used to improve subpixel font rendering. Only affects fonts smaller than the subpixel limit.
-    /// @property
     int GetFontOversampling() const { return fontOversampling_; }
 
     /// Return true when UI has modal element(s).
@@ -240,11 +202,9 @@ public:
     bool IsDragging() const { return dragConfirmedCount_ > 0; };
 
     /// Return current UI scale.
-    /// @property
     float GetScale() const { return uiScale_; }
 
     /// Return root element custom size. Returns 0,0 when custom size is not being used and automatic resizing according to window size is in use instead (default).
-    /// @property
     const IntVector2& GetCustomSize() const { return customSize_; }
 
     /// Set texture to which element will be rendered.

--- a/source/dviglo/ui/ui_component.h
+++ b/source/dviglo/ui/ui_component.h
@@ -33,13 +33,10 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UIElement.
-    /// @property
     UIElement* GetRoot() const;
     /// Return material which will be used for rendering UI texture.
-    /// @property
     Material* GetMaterial() const;
     /// Return texture which will be used for rendering UI to.
-    /// @property
     Texture2D* GetTexture() const;
     /// Set index of viewport to be used for screen coordinate translation.
     void SetViewportIndex(unsigned index);

--- a/source/dviglo/ui/ui_element.h
+++ b/source/dviglo/ui/ui_element.h
@@ -265,7 +265,6 @@ public:
     /// Set color on all corners.
     void SetColor(const Color& color);
     /// Set color on one corner.
-    /// @property{set_colors}
     void SetColor(Corner corner, const Color& color);
     /// Set priority.
     void SetPriority(int priority);
@@ -475,7 +474,6 @@ public:
     const IntRect& GetClipBorder() const { return clipBorder_; }
 
     /// Return corner color.
-    /// @property{get_colors}
     const Color& GetColor(Corner corner) const { return colors_[corner]; }
 
     /// Return priority.
@@ -503,7 +501,6 @@ public:
     bool GetUseDerivedOpacity() const { return useDerivedOpacity_; }
 
     /// Return whether has focus.
-    /// @property{get_focus}
     bool HasFocus() const;
 
     /// Return whether is a direct or indirect child of specified element.
@@ -534,7 +531,6 @@ public:
     bool IsInternal() const { return internal_; }
 
     /// Return whether has different color in at least one corner.
-    /// @property{get_colorGradient}
     bool HasColorGradient() const { return colorGradient_; }
 
     /// Return focus mode.
@@ -544,7 +540,6 @@ public:
     DragAndDropModeFlags GetDragDropMode() const { return dragDropMode_; }
 
     /// Return applied style name. Return an empty string when the applied style is an 'auto' style (i.e. style derived from instance's type).
-    /// @property{get_style}
     const String& GetAppliedStyle() const;
     /// Return default style.
     XMLFile* GetDefaultStyle(bool recursiveUp = true) const;
@@ -565,7 +560,6 @@ public:
     i32 GetNumChildren(bool recursive = false) const;
 
     /// Return child element by index.
-    /// @property{get_children}
     UIElement* GetChild(i32 index) const;
 
     /// Return child element by name.

--- a/source/dviglo/ui/ui_element.h
+++ b/source/dviglo/ui/ui_element.h
@@ -130,7 +130,6 @@ public:
     /// Return whether is visible and inside a scissor rectangle and should be rendered.
     virtual bool IsWithinScissor(const IntRect& currentScissor);
     /// Update and return screen position.
-    /// @property
     virtual const IntVector2& GetScreenPosition() const;
     /// Return UI rendering batches.
     virtual void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor);
@@ -200,45 +199,34 @@ public:
     bool FilterAttributes(XMLElement& dest) const;
 
     /// Set name.
-    /// @property
     void SetName(const String& name);
     /// Set position.
-    /// @property
     void SetPosition(const IntVector2& position);
     /// Set position.
     void SetPosition(int x, int y);
     /// Set size.
-    /// @property
     void SetSize(const IntVector2& size);
     /// Set size.
     void SetSize(int width, int height);
     /// Set width only.
-    /// @property
     void SetWidth(int width);
     /// Set height only.
-    /// @property
     void SetHeight(int height);
     /// Set minimum size.
-    /// @property
     void SetMinSize(const IntVector2& minSize);
     /// Set minimum size.
     void SetMinSize(int width, int height);
     /// Set minimum width.
-    /// @property
     void SetMinWidth(int width);
     /// Set minimum height.
-    /// @property
     void SetMinHeight(int height);
     /// Set maximum size.
-    /// @property
     void SetMaxSize(const IntVector2& maxSize);
     /// Set maximum size.
     void SetMaxSize(int width, int height);
     /// Set maximum width.
-    /// @property
     void SetMaxWidth(int width);
     /// Set maximum height.
-    /// @property
     void SetMaxHeight(int height);
     /// Set fixed size.
     void SetFixedSize(const IntVector2& size);
@@ -251,67 +239,49 @@ public:
     /// Set horizontal and vertical alignment.
     void SetAlignment(HorizontalAlignment hAlign, VerticalAlignment vAlign);
     /// Set horizontal alignment.
-    /// @property
     void SetHorizontalAlignment(HorizontalAlignment align);
     /// Set vertical alignment.
-    /// @property
     void SetVerticalAlignment(VerticalAlignment align);
     /// Enable automatic positioning & sizing of the element relative to its parent using min/max anchor and min/max offset. Default false.
-    /// @property
     void SetEnableAnchor(bool enable);
     /// Set minimum (top left) anchor in relation to the parent element (from 0 to 1). No effect when anchor is not enabled.
-    /// @property
     void SetMinAnchor(const Vector2& anchor);
     /// Set minimum anchor.
     void SetMinAnchor(float x, float y);
     /// Set maximum (bottom right) anchor in relation to the parent element (from 0 to 1). No effect when anchor is not enabled.
-    /// @property
     void SetMaxAnchor(const Vector2& anchor);
     /// Set maximum anchor.
     void SetMaxAnchor(float x, float y);
     /// Set offset of element's top left from the minimum anchor in pixels. No effect when anchor is not enabled.
-    /// @property
     void SetMinOffset(const IntVector2& offset);
     /// Set offset of element's bottom right from the maximum anchor in pixels. No effect when anchor is not enabled.
-    /// @property
     void SetMaxOffset(const IntVector2& offset);
     /// Set pivot relative to element's size (from 0 to 1, where 0.5 is center). Overrides horizontal & vertical alignment.
-    /// @property
     void SetPivot(const Vector2& pivot);
     /// Set pivot relative to element's size (from 0 to 1, where 0.5 is center). Overrides horizontal & vertical alignment.
     void SetPivot(float x, float y);
     /// Set child element clipping border.
-    /// @property
     void SetClipBorder(const IntRect& rect);
     /// Set color on all corners.
-    /// @property
     void SetColor(const Color& color);
     /// Set color on one corner.
     /// @property{set_colors}
     void SetColor(Corner corner, const Color& color);
     /// Set priority.
-    /// @property
     void SetPriority(int priority);
     /// Set opacity.
-    /// @property
     void SetOpacity(float opacity);
     /// Set whether should be brought to front when focused.
-    /// @property
     void SetBringToFront(bool enable);
     /// Set whether should be put to background when another element is focused.
-    /// @property
     void SetBringToBack(bool enable);
     /// Set whether should clip child elements. Default false.
-    /// @property
     void SetClipChildren(bool enable);
     /// Set whether should sort child elements according to priority. Default true.
-    /// @property
     void SetSortChildren(bool enable);
     /// Set whether parent elements' opacity affects opacity. Default true.
-    /// @property
     void SetUseDerivedOpacity(bool enable);
     /// Set whether reacts to input. Default false, but is enabled by subclasses if applicable.
-    /// @property
     void SetEnabled(bool enable);
     /// Set enabled state on self and child elements. Elements' own enabled state is remembered (IsEnabledSelf) and can be restored.
     void SetDeepEnabled(bool enable);
@@ -320,22 +290,16 @@ public:
     /// Set enabled state on self and child elements. Unlike SetDeepEnabled this does not remember the elements' own enabled state, but overwrites it.
     void SetEnabledRecursive(bool enable);
     /// Set whether value is editable through input. Not applicable to all elements. Default true.
-    /// @property
     void SetEditable(bool enable);
     /// Set whether is focused. Only one element can be focused at a time.
-    /// @property
     void SetFocus(bool enable);
     /// Set selected mode. Actual meaning is element dependent, for example constant hover or pressed effect.
-    /// @property
     void SetSelected(bool enable);
     /// Set whether is visible. Visibility propagates to child elements.
-    /// @property
     void SetVisible(bool enable);
     /// Set focus mode.
-    /// @property
     void SetFocusMode(FocusMode mode);
     /// Set drag and drop flags.
-    /// @property
     void SetDragDropMode(DragAndDropModeFlags mode);
     /// Set style from an XML file. Find the style element by name. If the style file is not explicitly provided, use the default style from parental chain. Return true if the style is applied successfully. See also \ref UI_Programmatic.
     bool SetStyle(const String& styleName, XMLFile* file = nullptr);
@@ -344,27 +308,20 @@ public:
     /// Set style from an XML file. Find the style element automatically by using the element's typename. If the style file is not explicitly provided, use the default style from parental chain. Return true if the style is applied successfully. See also \ref UI_Programmatic.
     bool SetStyleAuto(XMLFile* file = nullptr);
     /// Set default style file for later use by children elements.
-    /// @property
     void SetDefaultStyle(XMLFile* style);
     /// Set layout parameters.
     void SetLayout(LayoutMode mode, int spacing = 0, const IntRect& border = IntRect::ZERO);
     /// Set layout mode only.
-    /// @property
     void SetLayoutMode(LayoutMode mode);
     /// Set layout spacing.
-    /// @property
     void SetLayoutSpacing(int spacing);
     /// Set layout border.
-    /// @property
     void SetLayoutBorder(const IntRect& border);
     /// Set layout flex scale.
-    /// @property
     void SetLayoutFlexScale(const Vector2& scale);
     /// Set horizontal indentation.
-    /// @property
     void SetIndent(int indent);
     /// Set indent spacing (number of pixels per indentation level).
-    /// @property
     void SetIndentSpacing(int indentSpacing);
     /// Manually update layout. Should not be necessary in most cases, but is provided for completeness.
     void UpdateLayout();
@@ -405,13 +362,10 @@ public:
     /// Set a user variable.
     void SetVar(StringHash key, const Variant& value);
     /// Mark as internally (programmatically) created. Used when an element composes itself out of child elements.
-    /// @property
     void SetInternal(bool enable);
     /// Set traversal mode for rendering. The default traversal mode is TM_BREADTH_FIRST for non-root element. Root element should be set to TM_DEPTH_FIRST to avoid artifacts during rendering.
-    /// @property
     void SetTraversalMode(TraversalMode traversalMode);
     /// Set element event sender flag. When child element is added or deleted, the event would be sent using UIElement found in the parental chain having this flag set. If not set, the event is sent using UI's root as per normal.
-    /// @property
     void SetElementEventSender(bool flag);
 
     /// Set tags. Old tags are overwritten.
@@ -449,99 +403,75 @@ public:
     template <class T> T* GetChildDynamicCast(const StringHash& key, const Variant& value = Variant::EMPTY, bool recursive = false) const;
 
     /// Return name.
-    /// @property
     const String& GetName() const { return name_; }
 
     /// Return position.
-    /// @property
     const IntVector2& GetPosition() const { return position_; }
 
     /// Return size.
-    /// @property
     const IntVector2& GetSize() const { return size_; }
 
     /// Return width.
-    /// @property
     int GetWidth() const { return size_.x_; }
 
     /// Return height.
-    /// @property
     int GetHeight() const { return size_.y_; }
 
     /// Return minimum size.
-    /// @property
     const IntVector2& GetMinSize() const { return minSize_; }
 
     /// Return minimum width.
-    /// @property
     int GetMinWidth() const { return minSize_.x_; }
 
     /// Return minimum height.
-    /// @property
     int GetMinHeight() const { return minSize_.y_; }
 
     /// Return maximum size.
-    /// @property
     const IntVector2& GetMaxSize() const { return maxSize_; }
 
     /// Return minimum width.
-    /// @property
     int GetMaxWidth() const { return maxSize_.x_; }
 
     /// Return minimum height.
-    /// @property
     int GetMaxHeight() const { return maxSize_.y_; }
 
     /// Return true if size is fixed.
-    /// @property
     bool IsFixedSize() const { return minSize_ == maxSize_; }
 
     /// Return true if width is fixed.
-    /// @property
     bool IsFixedWidth() const { return minSize_.x_ == maxSize_.x_; }
 
     /// Return true if height is fixed.
-    /// @property
     bool IsFixedHeight() const { return minSize_.y_ == maxSize_.y_; }
 
     /// Return child element offset.
-    /// @property
     const IntVector2& GetChildOffset() const { return childOffset_; }
 
     /// Return horizontal alignment. If pivot has been adjusted to a custom horizontal setting, returns HA_CUSTOM.
-    /// @property
     HorizontalAlignment GetHorizontalAlignment() const;
 
     /// Return vertical alignment. If pivot has been adjusted to a custom vertical setting, returns VA_CUSTOM.
-    /// @property
     VerticalAlignment GetVerticalAlignment() const;
 
     /// Return whether anchor positioning & sizing is enabled.
-    /// @property
     bool GetEnableAnchor() const { return enableAnchor_; }
 
     /// Return minimum anchor.
-    /// @property
     const Vector2& GetMinAnchor() const { return anchorMin_; }
 
     /// Return maximum anchor.
-    /// @property
     const Vector2& GetMaxAnchor() const { return anchorMax_; }
 
     // Return minimum offset.
-    /// @property
     const IntVector2& GetMinOffset() const { return minOffset_; }
 
     // Return maximum offset.
-    /// @property
     const IntVector2& GetMaxOffset() const { return maxOffset_; }
 
     /// Return pivot.
-    /// @property
     const Vector2& GetPivot() const { return pivot_; }
 
     /// Return child element clipping border.
-    /// @property
     const IntRect& GetClipBorder() const { return clipBorder_; }
 
     /// Return corner color.
@@ -549,35 +479,27 @@ public:
     const Color& GetColor(Corner corner) const { return colors_[corner]; }
 
     /// Return priority.
-    /// @property
     int GetPriority() const { return priority_; }
 
     /// Return opacity.
-    /// @property
     float GetOpacity() const { return opacity_; }
 
     /// Return derived opacity (affected by parent elements). If UseDerivedOpacity is false, returns same as element's own opacity.
-    /// @property
     float GetDerivedOpacity() const;
 
     /// Return whether should be brought to front when focused.
-    /// @property
     bool GetBringToFront() const { return bringToFront_; }
 
     /// Return whether should be put to background when another element is focused.
-    /// @property
     bool GetBringToBack() const { return bringToBack_; }
 
     /// Return whether should clip child elements.
-    /// @property
     bool GetClipChildren() const { return clipChildren_; }
 
     /// Return whether should sort child elements according to priority.
-    /// @property
     bool GetSortChildren() const { return sortChildren_; }
 
     /// Return whether parent elements' opacity affects opacity.
-    /// @property
     bool GetUseDerivedOpacity() const { return useDerivedOpacity_; }
 
     /// Return whether has focus.
@@ -588,35 +510,27 @@ public:
     bool IsChildOf(UIElement* element) const;
 
     /// Return whether reacts to input.
-    /// @property
     bool IsEnabled() const { return enabled_; }
 
     /// Returns the element's last own enabled state. May be different than the value returned by IsEnabled when SetDeepEnabled has been used.
-    /// @property
     bool IsEnabledSelf() const { return enabledPrev_; }
 
     /// Return whether value is editable through input.
-    /// @property
     bool IsEditable() const { return editable_; }
 
     /// Return whether is selected. Actual meaning is element dependent.
-    /// @property
     bool IsSelected() const { return selected_; }
 
     /// Return whether element itself should be visible. Elements can be also hidden due to the parent being not visible, use IsVisibleEffective() to check.
-    /// @property
     bool IsVisible() const { return visible_; }
 
     /// Return whether element is effectively visible (parent element chain is visible).
-    /// @property
     bool IsVisibleEffective() const;
 
     /// Return whether the cursor is hovering on this element.
-    /// @property
     bool IsHovering() const { return hovering_; }
 
     /// Return whether is internally created.
-    /// @property
     bool IsInternal() const { return internal_; }
 
     /// Return whether has different color in at least one corner.
@@ -624,11 +538,9 @@ public:
     bool HasColorGradient() const { return colorGradient_; }
 
     /// Return focus mode.
-    /// @property
     FocusMode GetFocusMode() const { return focusMode_; }
 
     /// Return drag and drop flags.
-    /// @property
     DragAndDropModeFlags GetDragDropMode() const { return dragDropMode_; }
 
     /// Return applied style name. Return an empty string when the applied style is an 'auto' style (i.e. style derived from instance's type).
@@ -638,19 +550,15 @@ public:
     XMLFile* GetDefaultStyle(bool recursiveUp = true) const;
 
     /// Return layout mode.
-    /// @property
     LayoutMode GetLayoutMode() const { return layoutMode_; }
 
     /// Return layout spacing.
-    /// @property
     int GetLayoutSpacing() const { return layoutSpacing_; }
 
     /// Return layout border.
-    /// @property
     const IntRect& GetLayoutBorder() const { return layoutBorder_; }
 
     /// Return layout flex scale.
-    /// @property
     const Vector2& GetLayoutFlexScale() const { return layoutFlexScale_; }
 
     /// Return number of child elements.
@@ -676,11 +584,9 @@ public:
     Vector<UIElement*> GetChildren(bool recursive) const;
 
     /// Return parent element.
-    /// @property
     UIElement* GetParent() const { return parent_; }
 
     /// Return root element.
-    /// @property
     UIElement* GetRoot() const;
     /// Return derived color. Only valid when no gradient.
     const Color& GetDerivedColor() const;
@@ -694,7 +600,6 @@ public:
     bool HasTag(const String& tag) const;
 
     /// Return all tags.
-    /// @property
     const StringVector& GetTags() const { return tags_; }
 
     /// Return child elements with a specific tag either recursively or non-recursively.
@@ -704,11 +609,9 @@ public:
     Vector<UIElement*> GetChildrenWithTag(const String& tag, bool recursive = false) const;
 
     /// Return the drag button combo if this element is being dragged.
-    /// @property
     MouseButtonFlags GetDragButtonCombo() const { return dragButtonCombo_; }
 
     /// Return the number of buttons dragging this element.
-    /// @property
     i32 GetDragButtonCount() const { return dragButtonCount_; }
 
     /// Return whether a point (either in element or screen coordinates) is inside the element.
@@ -716,7 +619,6 @@ public:
     /// Return whether a point (either in element or screen coordinates) is inside the combined rect of the element and its children.
     bool IsInsideCombined(IntVector2 position, bool isScreen);
     /// Return combined screen coordinate rect of element and its children.
-    /// @property
     IntRect GetCombinedScreenRect();
     /// Sort child elements if sorting enabled and order dirty. Called by UI.
     void SortChildren();
@@ -725,15 +627,12 @@ public:
     int GetLayoutElementMaxSize() const { return layoutElementMaxSize_; }
 
     /// Return horizontal indentation.
-    /// @property
     int GetIndent() const { return indent_; }
 
     /// Return indent spacing (number of pixels per indentation level).
-    /// @property
     int GetIndentSpacing() const { return indentSpacing_; }
 
     /// Return indent width in pixels.
-    /// @property
     int GetIndentWidth() const { return indent_ * indentSpacing_; }
 
     /// Set child offset.
@@ -749,11 +648,9 @@ public:
     const Color& GetColorAttr() const { return colors_[0]; }
 
     /// Return traversal mode for rendering.
-    /// @property
     TraversalMode GetTraversalMode() const { return traversalMode_; }
 
     /// Return whether element should send child added / removed events by itself. If false, defers to parent element.
-    /// @property
     bool IsElementEventSender() const { return elementEventSender_; }
 
     /// Get element which should send child added / removed events.

--- a/source/dviglo/ui/ui_selectable.h
+++ b/source/dviglo/ui/ui_selectable.h
@@ -28,17 +28,13 @@ public:
     void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// Set selection background color. Color with 0 alpha (default) disables.
-    /// @property
     void SetSelectionColor(const Color& color);
     /// Set hover background color. Color with 0 alpha (default) disables.
-    /// @property
     void SetHoverColor(const Color& color);
 
     /// Return selection background color.
-    /// @property
     const Color& GetSelectionColor() const { return selectionColor_; }
     /// Return hover background color.
-    /// @property
     const Color& GetHoverColor() const { return hoverColor_; }
 
 protected:

--- a/source/dviglo/ui/view_3d.h
+++ b/source/dviglo/ui/view_3d.h
@@ -35,36 +35,27 @@ public:
     /// Define the scene and camera to use in rendering. When ownScene is true the View3D will take ownership of them with shared pointers.
     void SetView(Scene* scene, Camera* camera, bool ownScene = true);
     /// Set render texture pixel format. Default is RGB.
-    /// @property
     void SetFormat(unsigned format);
     /// Set render target auto update mode. Default is true.
-    /// @property
     void SetAutoUpdate(bool enable);
     /// Queue manual update on the render texture.
     void QueueUpdate();
 
     /// Return render texture pixel format.
-    /// @property
     unsigned GetFormat() const { return rttFormat_; }
 
     /// Return whether render target updates automatically.
-    /// @property
     bool GetAutoUpdate() const { return autoUpdate_; }
 
     /// Return scene.
-    /// @property
     Scene* GetScene() const;
     /// Return camera scene node.
-    /// @property
     Node* GetCameraNode() const;
     /// Return render texture.
-    /// @property
     Texture2D* GetRenderTexture() const;
     /// Return depth stencil texture.
-    /// @property
     Texture2D* GetDepthTexture() const;
     /// Return viewport.
-    /// @property
     Viewport* GetViewport() const;
 
 private:

--- a/source/dviglo/ui/window.h
+++ b/source/dviglo/ui/window.h
@@ -60,74 +60,54 @@ public:
         OnDragCancel(const IntVector2& position, const IntVector2& screenPosition, MouseButtonFlags dragButtons, MouseButtonFlags cancelButtons, Cursor* cursor) override;
 
     /// Set whether can be moved.
-    /// @property
     void SetMovable(bool enable);
     /// Set whether can be resized.
-    /// @property
     void SetResizable(bool enable);
     /// Set whether resizing width is fixed.
-    /// @property
     void SetFixedWidthResizing(bool enable);
     /// Set whether resizing height is fixed.
-    /// @property
     void SetFixedHeightResizing(bool enable);
     /// Set resize area width at edges.
-    /// @property
     void SetResizeBorder(const IntRect& rect);
     /// Set modal flag. When the modal flag is set, the focused window needs to be dismissed first to allow other UI elements to gain focus.
-    /// @property
     void SetModal(bool modal);
     /// Set modal shade color.
-    /// @property
     void SetModalShadeColor(const Color& color);
     /// Set modal frame color.
-    /// @property
     void SetModalFrameColor(const Color& color);
     /// Set modal frame size.
-    /// @property
     void SetModalFrameSize(const IntVector2& size);
     /// Set whether model window can be dismissed with the escape key. Default true.
-    /// @property
     void SetModalAutoDismiss(bool enable);
 
     /// Return whether is movable.
-    /// @property
     bool IsMovable() const { return movable_; }
 
     /// Return whether is resizable.
-    /// @property
     bool IsResizable() const { return resizable_; }
 
     /// Return whether is resizing width is fixed.
-    /// @property
     bool GetFixedWidthResizing() const { return fixedWidthResizing_; }
 
     /// Return whether is resizing height is fixed.
-    /// @property
     bool GetFixedHeightResizing() const { return fixedHeightResizing_; }
 
     /// Return resize area width at edges.
-    /// @property
     const IntRect& GetResizeBorder() const { return resizeBorder_; }
 
     /// Return modal flag.
-    /// @property
     bool IsModal() const { return modal_; }
 
     /// Get modal shade color.
-    /// @property
     const Color& GetModalShadeColor() const { return modalShadeColor_; }
 
     /// Get modal frame color.
-    /// @property
     const Color& GetModalFrameColor() const { return modalFrameColor_; }
 
     /// Get modal frame size.
-    /// @property
     const IntVector2& GetModalFrameSize() const { return modalFrameSize_; }
 
     /// Return whether can be dismissed with escape key.
-    /// @property
     bool GetModalAutoDismiss() const { return modalAutoDismiss_; }
 
 protected:

--- a/source/dviglo/urho_2d/animated_sprite_2d.h
+++ b/source/dviglo/urho_2d/animated_sprite_2d.h
@@ -55,34 +55,25 @@ public:
     void OnSetEnabled() override;
 
     /// Set animation set.
-    /// @property
     void SetAnimationSet(AnimationSet2D* animationSet);
     /// Set entity name (skin name for spine, entity name for spriter).
-    /// @property
     void SetEntity(const String& entity);
     /// Set animation by name and loop mode.
     void SetAnimation(const String& name, LoopMode2D loopMode = LM_DEFAULT);
     /// Set loop mode.
-    /// @property
     void SetLoopMode(LoopMode2D loopMode);
     /// Set speed.
-    /// @property
     void SetSpeed(float speed);
 
     /// Return animation.
-    /// @property
     AnimationSet2D* GetAnimationSet() const;
     /// Return entity name.
-    /// @property
     const String& GetEntity() const { return entity_; }
     /// Return animation name.
-    /// @property
     const String& GetAnimation() const { return animationName_; }
     /// Return loop mode.
-    /// @property
     LoopMode2D GetLoopMode() const { return loopMode_; }
     /// Return speed.
-    /// @property
     float GetSpeed() const { return speed_; }
 
     /// Set animation set attribute.

--- a/source/dviglo/urho_2d/animated_sprite_2d.h
+++ b/source/dviglo/urho_2d/animated_sprite_2d.h
@@ -81,7 +81,6 @@ public:
     /// Return animation set attribute.
     ResourceRef GetAnimationSetAttr() const;
     /// Set animation by name.
-    /// @property{set_animation}
     void SetAnimationAttr(const String& name);
 
 protected:

--- a/source/dviglo/urho_2d/animation_set_2d.h
+++ b/source/dviglo/urho_2d/animation_set_2d.h
@@ -46,7 +46,6 @@ public:
     bool EndLoad() override;
 
     /// Get number of animations.
-    /// @property
     unsigned GetNumAnimations() const;
     /// Return animation name.
     String GetAnimation(unsigned index) const;

--- a/source/dviglo/urho_2d/drawable_2d.h
+++ b/source/dviglo/urho_2d/drawable_2d.h
@@ -63,18 +63,14 @@ public:
     void OnSetEnabled() override;
 
     /// Set layer.
-    /// @property
     void SetLayer(int layer);
     /// Set order in layer.
-    /// @property
     void SetOrderInLayer(int orderInLayer);
 
     /// Return layer.
-    /// @property
     int GetLayer() const { return layer_; }
 
     /// Return order in layer.
-    /// @property
     int GetOrderInLayer() const { return orderInLayer_; }
 
     /// Return all source batches (called by Renderer2D).

--- a/source/dviglo/urho_2d/particle_emitter_2d.h
+++ b/source/dviglo/urho_2d/particle_emitter_2d.h
@@ -72,29 +72,22 @@ public:
     void OnSetEnabled() override;
 
     /// Set particle effect.
-    /// @property
     void SetEffect(ParticleEffect2D* effect);
     /// Set sprite.
-    /// @property
     void SetSprite(Sprite2D* sprite);
     /// Set blend mode.
-    /// @property
     void SetBlendMode(BlendMode blendMode);
     /// Set max particles.
     void SetMaxParticles(unsigned maxParticles);
     /// Set whether should be emitting. If the state was changed, also resets the emission period timer.
-    /// @property
     void SetEmitting(bool enable);
 
     /// Return particle effect.
-    /// @property
     ParticleEffect2D* GetEffect() const;
     /// Return sprite.
-    /// @property
     Sprite2D* GetSprite() const;
 
     /// Return blend mode.
-    /// @property
     BlendMode GetBlendMode() const { return blendMode_; }
 
     /// Return max particles.
@@ -109,7 +102,6 @@ public:
     /// Return sprite attribute.
     ResourceRef GetSpriteAttr() const;
     /// Return whether is currently emitting.
-    /// @property
     bool IsEmitting() const { return emitting_; }
 
 private:

--- a/source/dviglo/urho_2d/sprite_2d.h
+++ b/source/dviglo/urho_2d/sprite_2d.h
@@ -33,41 +33,31 @@ public:
     bool EndLoad() override;
 
     /// Set texture.
-    /// @property
     void SetTexture(Texture2D* texture);
     /// Set rectangle.
-    /// @property
     void SetRectangle(const IntRect& rectangle);
     /// Set hot spot.
-    /// @property
     void SetHotSpot(const Vector2& hotSpot);
     /// Set offset.
-    /// @property
     void SetOffset(const IntVector2& offset);
     /// Set texture edge offset in pixels. This affects the left/right and top/bottom edges equally to prevent edge sampling artifacts. Default 0.
-    /// @property
     void SetTextureEdgeOffset(float offset);
     /// Set sprite sheet.
     void SetSpriteSheet(SpriteSheet2D* spriteSheet);
 
     /// Return texture.
-    /// @property
     Texture2D* GetTexture() const { return texture_; }
 
     /// Return rectangle.
-    /// @property
     const IntRect& GetRectangle() const { return rectangle_; }
 
     /// Return hot spot.
-    /// @property
     const Vector2& GetHotSpot() const { return hotSpot_; }
 
     /// Return offset.
-    /// @property
     const IntVector2& GetOffset() const { return offset_; }
 
     /// Return texture edge offset.
-    /// @property
     float GetTextureEdgeOffset() const { return edgeOffset_; }
 
     /// Return sprite sheet.

--- a/source/dviglo/urho_2d/sprite_sheet_2d.h
+++ b/source/dviglo/urho_2d/sprite_sheet_2d.h
@@ -35,14 +35,12 @@ public:
     bool EndLoad() override;
 
     /// Set texture.
-    /// @property
     void SetTexture(Texture2D* texture);
     /// Define sprite.
     void DefineSprite(const String& name, const IntRect& rectangle, const Vector2& hotSpot = Vector2(0.5f, 0.5f),
         const IntVector2& offset = IntVector2::ZERO);
 
     /// Return texture.
-    /// @property
     Texture2D* GetTexture() const { return texture_; }
     /// Return sprite.
     Sprite2D* GetSprite(const String& name) const;

--- a/source/dviglo/urho_2d/static_sprite_2d.h
+++ b/source/dviglo/urho_2d/static_sprite_2d.h
@@ -26,104 +26,76 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set sprite.
-    /// @property
     void SetSprite(Sprite2D* sprite);
     /// Set draw rectangle.
-    /// @property
     void SetDrawRect(const Rect &rect);
     /// Set texture rectangle.
-    /// @property
     void SetTextureRect(const Rect &rect);
     /// Set blend mode.
-    /// @property
     void SetBlendMode(BlendMode blendMode);
     /// Set flip.
     void SetFlip(bool flipX, bool flipY, bool swapXY = false);
     /// Set flip X.
-    /// @property
     void SetFlipX(bool flipX);
     /// Set flip Y.
-    /// @property
     void SetFlipY(bool flipY);
     /// Set swap X and Y.
-    /// @property
     void SetSwapXY(bool swapXY);
     /// Set color.
-    /// @property
     void SetColor(const Color& color);
     /// Set alpha.
-    /// @property
     void SetAlpha(float alpha);
     /// Set whether to use custom-defined hot spot.
-    /// @property
     void SetUseHotSpot(bool useHotSpot);
     /// Set whether to use custom-defined draw rectangle.
-    /// @property
     void SetUseDrawRect(bool useDrawRect);
     /// Set whether to use custom-defined texture rectangle.
-    /// @property
     void SetUseTextureRect(bool useTextureRect);
     /// Set hot spot.
-    /// @property
     void SetHotSpot(const Vector2& hotspot);
     /// Set custom material.
-    /// @property
     void SetCustomMaterial(Material* customMaterial);
 
     /// Return sprite.
-    /// @property
     Sprite2D* GetSprite() const;
 
     /// Return draw rect.
-    /// @property
     const Rect& GetDrawRect() const { return drawRect_; }
 
     /// Return texture rect.
-    /// @property
     const Rect& GetTextureRect() const { return textureRect_; }
 
     /// Return blend mode.
-    /// @property
     BlendMode GetBlendMode() const { return blendMode_; }
 
     /// Return flip X.
-    /// @property
     bool GetFlipX() const { return flipX_; }
 
     /// Return flip Y.
-    /// @property
     bool GetFlipY() const { return flipY_; }
 
     /// Return swap X and Y.
-    /// @property
     bool GetSwapXY() const { return swapXY_; }
 
     /// Return color.
-    /// @property
     const Color& GetColor() const { return color_; }
 
     /// Return alpha.
-    /// @property
     float GetAlpha() const { return color_.a_; }
 
     /// Return whether to use custom-defined hot spot.
-    /// @property
     bool GetUseHotSpot() const { return useHotSpot_; }
 
     /// Return whether to use custom-defined draw rectangle.
-    /// @property
     bool GetUseDrawRect() const { return useDrawRect_; }
 
     /// Return whether to use custom-defined texture rectangle.
-    /// @property
     bool GetUseTextureRect() const { return useTextureRect_; }
 
     /// Return hot spot.
-    /// @property
     const Vector2& GetHotSpot() const { return hotSpot_; }
 
     /// Return custom material.
-    /// @property
     Material* GetCustomMaterial() const;
 
     /// Set sprite attribute.

--- a/source/dviglo/urho_2d/stretchable_sprite_2d.h
+++ b/source/dviglo/urho_2d/stretchable_sprite_2d.h
@@ -21,10 +21,8 @@ public:
     static void RegisterObject(Context* context);
 
     /// Set border as number of pixels from each side.
-    /// @property
     void SetBorder(const IntRect& border);
     /// Get border as number of pixels from each side.
-    /// @property
     const IntRect& GetBorder() const { return border_; }
 
 protected:

--- a/source/dviglo/urho_2d/tilemap_2d.h
+++ b/source/dviglo/urho_2d/tilemap_2d.h
@@ -31,21 +31,17 @@ public:
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
     /// Set tmx file.
-    /// @property
     void SetTmxFile(TmxFile2D* tmxFile);
     /// Add debug geometry to the debug renderer.
     void DrawDebugGeometry();
 
     /// Return tmx file.
-    /// @property
     TmxFile2D* GetTmxFile() const;
 
     /// Return information.
-    /// @property
     const TileMapInfo2D& GetInfo() const { return info_; }
 
     /// Return number of layers.
-    /// @property
     unsigned GetNumLayers() const { return layers_.Size(); }
 
     /// Return tile map layer at index.

--- a/source/dviglo/urho_2d/tilemap_defs_2d.h
+++ b/source/dviglo/urho_2d/tilemap_defs_2d.h
@@ -43,10 +43,8 @@ struct URHO3D_API TileMapInfo2D
     float tileHeight_;
 
     /// Return map width.
-    /// @property
     float GetMapWidth() const;
     /// return map height.
-    /// @property
     float GetMapHeight() const;
     /// Convert tmx position to Urho position.
     Vector2 ConvertPosition(const Vector2& position) const;
@@ -120,20 +118,15 @@ public:
     Tile2D();
 
     /// Return gid.
-    /// @property
     unsigned GetGid() const { return gid_ & ~FLIP_ALL; }
     /// Return flip X.
-    /// @property
     bool GetFlipX() const { return gid_ & FLIP_HORIZONTAL; }
     /// Return flip Y.
-    /// @property
     bool GetFlipY() const { return gid_ & FLIP_VERTICAL; }
     /// Return swap X and Y.
-    /// @property
     bool GetSwapXY() const { return gid_ & FLIP_DIAGONAL; }
 
     /// Return sprite.
-    /// @property
     Sprite2D* GetSprite() const;
     /// Return has property.
     bool HasProperty(const String& name) const;
@@ -158,46 +151,35 @@ public:
     TileMapObject2D();
 
     /// Return type.
-    /// @property
     TileMapObjectType2D GetObjectType() const { return objectType_; }
 
     /// Return name.
-    /// @property
     const String& GetName() const { return name_; }
 
     /// Return type.
-    /// @property
     const String& GetType() const { return type_; }
 
     /// Return position.
-    /// @property
     const Vector2& GetPosition() const { return position_; }
 
     /// Return size (for rectangle and ellipse).
-    /// @property
     const Vector2& GetSize() const { return size_; }
 
     /// Return number of points (use for script).
-    /// @property
     unsigned GetNumPoints() const;
     /// Return point at index (use for script).
     const Vector2& GetPoint(unsigned index) const;
 
     /// Return tile Gid.
-    /// @property
     unsigned GetTileGid() const { return gid_ & ~FLIP_ALL; }
     /// Return tile flip X.
-    /// @property
     bool GetTileFlipX() const { return gid_ & FLIP_HORIZONTAL; }
     /// Return tile flip Y.
-    /// @property
     bool GetTileFlipY() const { return gid_ & FLIP_VERTICAL; }
     /// Return tile swap X and Y.
-    /// @property
     bool GetTileSwapXY() const { return gid_ & FLIP_DIAGONAL; }
 
     /// Return tile sprite.
-    /// @property
     Sprite2D* GetTileSprite() const;
     /// Return has property.
     bool HasProperty(const String& name) const;

--- a/source/dviglo/urho_2d/tilemap_layer_2d.h
+++ b/source/dviglo/urho_2d/tilemap_layer_2d.h
@@ -42,10 +42,8 @@ public:
     /// Initialize with tile map and tmx layer.
     void Initialize(TileMap2D* tileMap, const TmxLayer2D* tmxLayer);
     /// Set draw order.
-    /// @property
     void SetDrawOrder(int drawOrder);
     /// Set visible.
-    /// @property
     void SetVisible(bool visible);
 
     /// Return tile map.
@@ -55,11 +53,9 @@ public:
     const TmxLayer2D* GetTmxLayer() const { return tmxLayer_; }
 
     /// Return draw order.
-    /// @property
     int GetDrawOrder() const { return drawOrder_; }
 
     /// Return visible.
-    /// @property
     bool IsVisible() const { return visible_; }
 
     /// Return has property.
@@ -67,14 +63,11 @@ public:
     /// Return property.
     const String& GetProperty(const String& name) const;
     /// Return layer type.
-    /// @property
     TileMapLayerType2D GetLayerType() const;
 
     /// Return width (for tile layer only).
-    /// @property
     int GetWidth() const;
     /// Return height (for tile layer only).
-    /// @property
     int GetHeight() const;
     /// Return tile node (for tile layer only).
     Node* GetTileNode(int x, int y) const;
@@ -82,7 +75,6 @@ public:
     Tile2D* GetTile(int x, int y) const;
 
     /// Return number of tile map objects (for object group only).
-    /// @property
     unsigned GetNumObjects() const;
     /// Return tile map object (for object group only).
     TileMapObject2D* GetObject(unsigned index) const;
@@ -90,7 +82,6 @@ public:
     Node* GetObjectNode(unsigned index) const;
 
     /// Return image node (for image layer only).
-    /// @property
     Node* GetImageNode() const;
 
 private:

--- a/source/dviglo/urho_2d/tmx_file_2d.h
+++ b/source/dviglo/urho_2d/tmx_file_2d.h
@@ -182,11 +182,9 @@ public:
     const TmxLayer2D* GetLayer(unsigned index) const;
 
     /// Set texture edge offset for all sprites, in pixels.
-    /// @property{set_edgeOffset}
     void SetSpriteTextureEdgeOffset(float offset);
 
     /// Return texture edge offset, in pixels.
-    /// @property{get_edgeOffset}
     float GetSpriteTextureEdgeOffset() const { return edgeOffset_; }
 
 private:


### PR DESCRIPTION
`@property` использовались в Urho3D для генератора привязок AngelScript, но в Dviglo скрипты выпилены

`@property` без фигурных скобок почистил так:

```
#!/bin/sh

find ./repo/source/dviglo -type f -exec perl -pi -e \
  's/\s*\/\/\/ \@property(\r?\n)//g' {} +
```

Про find читать тут https://github.com/dviglo/dviglo/pull/3
