### PR TITLE
Удалил квалификаторы точности из шейдеров

### DIFF
--- a/bin/core_data/shaders/lighting.glsl
+++ b/bin/core_data/shaders/lighting.glsl
@@ -244,7 +244,7 @@ float GetShadow(vec4 shadowPos)
     #endif
 }
 #else
-float GetShadow(highp vec4 shadowPos)
+float GetShadow(vec4 shadowPos)
 {
     #if defined(SIMPLE_SHADOW)
         // Take one sample
@@ -311,7 +311,7 @@ float GetDirShadow(const vec4 iShadowPos[NUMCASCADES], float depth)
     return GetDirShadowFade(GetShadow(shadowPos), depth);
 }
 #else
-float GetDirShadow(const highp vec4 iShadowPos[NUMCASCADES], float depth)
+float GetDirShadow(const vec4 iShadowPos[NUMCASCADES], float depth)
 {
     return GetDirShadowFade(GetShadow(iShadowPos[0]), depth);
 }
@@ -348,11 +348,7 @@ float GetDirShadowDeferred(vec4 projWorldPos, vec3 normal, float depth)
 #endif
 #endif
 
-#if !defined(GL_ES) || __VERSION__>=300
 float GetShadow(const vec4 iShadowPos[NUMCASCADES], float depth)
-#else
-float GetShadow(const highp vec4 iShadowPos[NUMCASCADES], float depth)
-#endif
 {
     #if defined(DIRLIGHT)
         return GetDirShadow(iShadowPos, depth);

--- a/bin/core_data/shaders/lit_particle.glsl
+++ b/bin/core_data/shaders/lit_particle.glsl
@@ -16,11 +16,7 @@ varying vec4 vWorldPos;
 #endif
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/lit_solid.glsl
+++ b/bin/core_data/shaders/lit_solid.glsl
@@ -18,11 +18,7 @@ varying vec4 vWorldPos;
 #endif
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/pbr_lit_solid.glsl
+++ b/bin/core_data/shaders/pbr_lit_solid.glsl
@@ -22,11 +22,7 @@ varying vec4 vWorldPos;
 #endif
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/pbr_terrain_blend.glsl
+++ b/bin/core_data/shaders/pbr_terrain_blend.glsl
@@ -11,11 +11,7 @@
 
 varying vec2 vTexCoord;
 
-#ifndef GL_ES
 varying vec2 vDetailTexCoord;
-#else
-varying mediump vec2 vDetailTexCoord;
-#endif
 varying vec3 vNormal;
 varying vec4 vWorldPos;
 #ifdef PERPIXEL
@@ -48,12 +44,7 @@ uniform sampler2D sDetailMap1;
 uniform sampler2D sDetailMap2;
 uniform sampler2D sDetailMap3;
 
-#ifndef GL_ES
 uniform vec2 cDetailTiling;
-#else
-uniform mediump vec2 cDetailTiling;
-#endif
-
 
 void VS()
 {

--- a/bin/core_data/shaders/pbr_terrain_blend.glsl
+++ b/bin/core_data/shaders/pbr_terrain_blend.glsl
@@ -16,11 +16,7 @@ varying vec3 vNormal;
 varying vec4 vWorldPos;
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/pbr_vegetation.glsl
+++ b/bin/core_data/shaders/pbr_vegetation.glsl
@@ -30,11 +30,7 @@ varying vec4 vWorldPos;
 #endif
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/postprocess.glsl
+++ b/bin/core_data/shaders/postprocess.glsl
@@ -64,21 +64,13 @@ vec3 Uncharted2Tonemap(vec3 x)
    return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
 }
 
-#if defined(GL_ES) && __VERSION__ >= 300
-#define defprec mediump
-#else
-#define defprec
-#endif
-
-#if !defined(GL_ES) || __VERSION__ >= 300
-vec3 ColorCorrection(vec3 color, defprec sampler3D lut)
+vec3 ColorCorrection(vec3 color, sampler3D lut)
 {
     float lutSize = 16.0; // Высота текстуры lut_identity.png
     float scale = (lutSize - 1.0) / lutSize;
     float offset = 1.0 / (2.0 * lutSize);
     return texture3D(lut, clamp(color, 0.0, 1.0) * scale + offset).rgb;
 }
-#endif
 
 const float Gamma = 2.2;
 const float InverseGamma = 1.0 / 2.2;

--- a/bin/core_data/shaders/samplers.glsl
+++ b/bin/core_data/shaders/samplers.glsl
@@ -10,22 +10,22 @@ uniform sampler2D sLightRampMap;
 uniform sampler2D sLightSpotMap;
 uniform samplerCube sLightCubeMap;
 #if !defined(GL_ES) || __VERSION__ >= 300
-    uniform highp sampler3D sVolumeMap;
+    uniform sampler3D sVolumeMap;
     uniform sampler2D sAlbedoBuffer;
     uniform sampler2D sNormalBuffer;
     uniform sampler2D sDepthBuffer;
     uniform sampler2D sLightBuffer;
     #ifdef VSM_SHADOW
-        uniform highp sampler2D sShadowMap;
+        uniform sampler2D sShadowMap;
     #else
-        uniform highp sampler2DShadow sShadowMap;
+        uniform sampler2DShadow sShadowMap;
     #endif
     uniform samplerCube sFaceSelectCubeMap;
     uniform samplerCube sIndirectionCubeMap;
     uniform samplerCube sZoneCubeMap;
-    uniform highp sampler3D sZoneVolumeMap;
+    uniform sampler3D sZoneVolumeMap;
 #else
-    uniform highp sampler2D sShadowMap;
+    uniform sampler2D sShadowMap;
 #endif
 
 #ifdef GL3

--- a/bin/core_data/shaders/terrain_blend.glsl
+++ b/bin/core_data/shaders/terrain_blend.glsl
@@ -7,12 +7,7 @@
 
 varying vec2 vTexCoord;
 
-#ifndef GL_ES
 varying vec2 vDetailTexCoord;
-#else
-varying mediump vec2 vDetailTexCoord;
-#endif
-
 varying vec3 vNormal;
 varying vec4 vWorldPos;
 #ifdef PERPIXEL
@@ -45,11 +40,7 @@ uniform sampler2D sDetailMap1;
 uniform sampler2D sDetailMap2;
 uniform sampler2D sDetailMap3;
 
-#ifndef GL_ES
 uniform vec2 cDetailTiling;
-#else
-uniform mediump vec2 cDetailTiling;
-#endif
 
 void VS()
 {

--- a/bin/core_data/shaders/terrain_blend.glsl
+++ b/bin/core_data/shaders/terrain_blend.glsl
@@ -12,11 +12,7 @@ varying vec3 vNormal;
 varying vec4 vWorldPos;
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/uniforms.glsl
+++ b/bin/core_data/shaders/uniforms.glsl
@@ -32,7 +32,7 @@ uniform mat4 cZone;
 #if !defined(GL_ES) || defined(WEBGL) || __VERSION__>=300
     uniform mat4 cLightMatrices[4];
 #else
-    uniform highp mat4 cLightMatrices[2];
+    uniform mat4 cLightMatrices[2];
 #endif
 #ifdef SKINNED
     uniform vec4 cSkinMatrices[MAXBONES*3];

--- a/bin/core_data/shaders/uniforms.glsl
+++ b/bin/core_data/shaders/uniforms.glsl
@@ -48,11 +48,6 @@ uniform mat4 cZone;
 #ifdef COMPILEPS
 
 // Fragment shader uniforms
-#if defined(MOBILE_GRAPHICS)
-    precision mediump float;
-#elif defined(WEBGL)
-    precision highp float;
-#endif
 uniform vec4 cAmbientColor;
 uniform vec3 cCameraPosPS;
 uniform float cDeltaTimePS;
@@ -159,12 +154,7 @@ uniform ObjectVS
 #ifdef COMPILEPS
 
 // Fragment shader uniforms
-#if defined(MOBILE_GRAPHICS)
-    precision mediump float;
-#elif defined(WEBGL)
-    precision highp float;
-#endif
-// Pixel shader uniforms
+
 uniform FramePS
 {
     float cDeltaTimePS;

--- a/bin/core_data/shaders/vegetation.glsl
+++ b/bin/core_data/shaders/vegetation.glsl
@@ -24,11 +24,7 @@ varying vec4 vWorldPos;
 #endif
 #ifdef PERPIXEL
     #ifdef SHADOW
-        #ifndef GL_ES
-            varying vec4 vShadowPos[NUMCASCADES];
-        #else
-            varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif
+        varying vec4 vShadowPos[NUMCASCADES];
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;

--- a/bin/core_data/shaders/water.glsl
+++ b/bin/core_data/shaders/water.glsl
@@ -4,17 +4,10 @@
 #include "screen_pos.glsl"
 #include "fog.glsl"
 
-#ifndef GL_ES
 varying vec4 vScreenPos;
 varying vec2 vReflectUV;
 varying vec2 vWaterUV;
 varying vec4 vEyeVec;
-#else
-varying highp vec4 vScreenPos;
-varying highp vec2 vReflectUV;
-varying highp vec2 vWaterUV;
-varying highp vec4 vEyeVec;
-#endif
 varying vec3 vNormal;
 
 #ifdef COMPILEVS


### PR DESCRIPTION
Литература:
* <https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.1.50.pdf> > `4.5 Precision and Precision Qualifiers`
* <https://registry.khronos.org/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf> > `4.5 Precision and Precision Qualifiers`
* <https://www.khronos.org/opengl/wiki/Type_Qualifier_(GLSL)>

В glsl есть квалификаторы точности `highp`, `mediump` и `lowp`. В десктопном glsl они ничего не делают и нужны только для совместимости с  OpenGL ES.

В OpenGL ES (в отличие от десктопного OpenGL) целые и вещественные числа могут иметь разный размер (очевидно в целях оптимизации), и квалификаторы точности указывают минимальную необходимую точность.
```
highp float x; // x должен использовать стандарт IEEE-754 и иметь размер 32 бита
```

Конструкция вида `precision квалификатор тип;` задаёт точность по умолчанию. Пример:
```
precision mediump float;
```

В HLSL тоже есть типы уменьшенного размера (`min12int`, `min10float` и т.п.):
* https://learn.microsoft.com/en-us/windows/uwp/gaming/glsl-to-hlsl-reference
* https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/using-hlsl-minimum-precision
* https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-scalar
