### PR TITLE
Удалил устаревшие текстурные форматы

### DIFF
--- a/bin/core_data/shaders/basic.glsl
+++ b/bin/core_data/shaders/basic.glsl
@@ -43,11 +43,7 @@ void PS()
         gl_FragColor = diffColor * diffInput;
     #endif
     #ifdef ALPHAMAP
-        #if defined(GL3) && !defined(GL_ES)
-            float alphaInput = texture2D(sDiffMap, vTexCoord).r;
-        #else
-            float alphaInput = texture2D(sDiffMap, vTexCoord).a;
-        #endif
+        float alphaInput = texture2D(sDiffMap, vTexCoord).r;
         gl_FragColor = vec4(diffColor.rgb, diffColor.a * alphaInput);
     #endif
 }

--- a/bin/core_data/shaders/text.glsl
+++ b/bin/core_data/shaders/text.glsl
@@ -113,11 +113,7 @@ void PS()
 #else
     #ifdef ALPHAMAP
         gl_FragColor.rgb = vColor.rgb;
-        #if defined(GL3) && !defined(GL_ES)
-            gl_FragColor.a = vColor.a * texture2D(sDiffMap, vTexCoord).r;
-        #else
-            gl_FragColor.a = vColor.a * texture2D(sDiffMap, vTexCoord).a;
-        #endif
+        gl_FragColor.a = vColor.a * texture2D(sDiffMap, vTexCoord).r;
     #else
         gl_FragColor = vColor * texture2D(sDiffMap, vTexCoord);
     #endif


### PR DESCRIPTION
Текстурные форматы `GL_ALPHA`, `GL_LUMINANCE`, `GL_LUMINANCE_ALPHA` [запрещены в OpenGL 3.0](https://registry.khronos.org/OpenGL/specs/gl/glspec30.pdf#page.408) и [удалены в OpenGL 3.2](https://registry.khronos.org/OpenGL/specs/gl/glspec32.core.pdf#page.332)

См. также конец статьи <https://www.khronos.org/opengl/wiki/Image_Format>.

Т.е. если текстура одноканальная, то в шейдерах OpenGL 3 всегда нужно читать канал `r`.

---

Таблица форматов текстур: <https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml>.

`glTexImage2D()` на вход получает текстуру, для которой нужно указать формат (`format`, `type`) входных данных. Эта текстура преобразуется в один из внутренних форматов (`internalformat`), который, как я понимаю, используется для хранения в памяти видеокарты.

Внутренние форматы `GL_RED` и `GL_R8` оба одноканальные, однако размер первого формата неизвестен:

> If internalformat is specified as a base internal format, the GL stores the resulting texture with internal component
> resolutions of its own choosing.

https://registry.khronos.org/OpenGL/specs/gl/glspec32.core.pdf#page.134

В OpenGL 4.6 [формулировка отличается](https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf#page.206):

> If internalformat is specified as a base internal format, the GL stores the resulting texture with
> internal component resolutions of its own choosing, referred to as the effective internal format.

То есть добавлена фраза, что этот выбранный внутренний формат называется "эффективным".